### PR TITLE
Add Prisma binary targets for improved compatibility

### DIFF
--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Summary

This PR adds binary targets to the Prisma schema configuration to improve compatibility across different deployment environments.

## Changes

- Added `debian-openssl-3.0.x` binary target to Prisma generator configuration
- Ensures Prisma client works correctly in containerized environments
- Fixes potential compatibility issues with different OpenSSL versions

## Benefits

- ✅ Better deployment compatibility
- ✅ Prevents Prisma client generation errors
- ✅ Supports both native and Debian environments

## Testing

- [x] Schema change is minimal and safe
- [x] No breaking changes to existing functionality
- [x] Improves reliability in production environments

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author