### PR TITLE
chore: standardize formatting and remove debug code

### DIFF
--- a/backend/controllers/authController.mjs
+++ b/backend/controllers/authController.mjs
@@ -9,8 +9,6 @@ import prisma from '../db/index.mjs';
  * Register a new user and create a corresponding user record.
  */
 export const register = async (req, res, next) => {
-  // eslint-disable-next-line no-console
-  console.log('REGISTER BODY:', req.body); // TEMPORARY FOR DEBUGGING
   try {
     const { username, email, password, firstName, lastName, money, level, xp, settings } = req.body; // Removed 'name' and 'role' from destructuring
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,21 +1,17 @@
-import { Toaster } from "@/components/ui/toaster";
-import { Toaster as Sonner } from "@/components/ui/sonner";
-
-import { useState } from "react";
-import { Toaster } from "@/components/ui/sonner";
-import { TooltipProvider } from "@/components/ui/tooltip";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
-import { navItems } from "./nav-items";
-import Index from "./pages/Index";
-import StableView from "./pages/StableView";
+import { Toaster as Sonner } from '@/components/ui/sonner';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { navItems } from './nav-items';
+import Index from './pages/Index';
+import StableView from './pages/StableView';
 
 const queryClient = new QueryClient();
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
-      <Toaster />
+      <Sonner />
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -1,4 +1,3 @@
-
 import React, { useState } from 'react';
 import { Menu, Star, Coins, Trophy } from 'lucide-react';
 import Sidebar from '../components/Sidebar';
@@ -16,22 +15,23 @@ const Index = () => {
       title: 'Shadowmere Reaches Level 15!',
       content: 'Your magnificent stallion has achieved a new milestone through dedicated training.',
       timestamp: '2 hours ago',
-      type: 'achievement' as const
+      type: 'achievement' as const,
     },
     {
       id: '2',
       title: 'Moonlight Tournament',
       content: 'Join the upcoming tournament under the silver moon. Registration ends tomorrow.',
       timestamp: '5 hours ago',
-      type: 'event' as const
+      type: 'event' as const,
     },
     {
       id: '3',
       title: 'New Stable Upgrades',
-      content: 'Magical enchantments are now available for your stable. Boost your horses\' abilities!',
+      content:
+        "Magical enchantments are now available for your stable. Boost your horses' abilities!",
       timestamp: '1 day ago',
-      type: 'update' as const
-    }
+      type: 'update' as const,
+    },
   ];
 
   return (
@@ -45,16 +45,14 @@ const Index = () => {
           >
             <Menu className="w-6 h-6 text-midnight-ink" />
           </button>
-          
-          <h1 className="fantasy-title text-3xl text-midnight-ink">
-            Equoria
-          </h1>
-          
+
+          <h1 className="fantasy-title text-3xl text-midnight-ink">Equoria</h1>
+
           <div className="w-10 h-10 bg-gradient-to-br from-burnished-gold to-aged-bronze rounded-full border-2 border-aged-bronze flex items-center justify-center">
             <Star className="w-5 h-5 text-parchment" />
           </div>
         </div>
-        
+
         {/* Decorative border */}
         <div className="absolute bottom-0 left-0 right-0 h-1 bg-gradient-to-r from-aged-bronze via-burnished-gold to-aged-bronze" />
       </header>
@@ -63,9 +61,7 @@ const Index = () => {
       <main className="p-4 space-y-8">
         {/* Welcome Section */}
         <div className="text-center space-y-4">
-          <h2 className="fantasy-header text-2xl text-midnight-ink">
-            Welcome back, Noble Rider
-          </h2>
+          <h2 className="fantasy-header text-2xl text-midnight-ink">Welcome back, Noble Rider</h2>
           <p className="fantasy-body text-aged-bronze">
             Your mystical companions await your return to the realm
           </p>
@@ -73,11 +69,7 @@ const Index = () => {
 
         {/* Featured Horse */}
         <section>
-          <FeaturedHorseCard
-            horseName="Stormwind"
-            breed="Celestial Stallion"
-            level={12}
-          />
+          <FeaturedHorseCard horseName="Stormwind" breed="Celestial Stallion" level={12} />
         </section>
 
         {/* Stats Grid */}
@@ -105,12 +97,8 @@ const Index = () => {
         {/* Action Buttons */}
         <section className="space-y-4">
           <div className="grid grid-cols-2 gap-4">
-            <FantasyButton variant="primary">
-              Visit Stable
-            </FantasyButton>
-            <FantasyButton variant="secondary">
-              Explore World
-            </FantasyButton>
+            <FantasyButton variant="primary">Visit Stable</FantasyButton>
+            <FantasyButton variant="secondary">Explore World</FantasyButton>
           </div>
           <FantasyButton variant="primary" size="large" className="w-full">
             Join Tournament

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,99 +1,90 @@
-import type { Config } from "tailwindcss";
+import type { Config } from 'tailwindcss';
 
 export default {
-	darkMode: "class",
-	content: [
-		"./pages/**/*.{ts,tsx}",
-		"./components/**/*.{ts,tsx}",
-		"./app/**/*.{ts,tsx}",
-		"./src/**/*.{ts,tsx}",
-	],
-	prefix: "",
-	theme: {
-		container: {
-			center: true,
-			padding: '2rem',
-			screens: {
-				'2xl': '1400px'
-			}
-		},
-		extend: {
-			colors: {
-				'forest-green': 'rgb(var(--forest-green) / <alpha-value>)',
-				'aged-bronze': 'rgb(var(--aged-bronze) / <alpha-value>)',
-				'burnished-gold': 'rgb(var(--burnished-gold) / <alpha-value>)',
-				'saddle-leather': 'rgb(var(--saddle-leather) / <alpha-value>)',
-				'parchment': 'rgb(var(--parchment) / <alpha-value>)',
-				'midnight-ink': 'rgb(var(--midnight-ink) / <alpha-value>)',
-				'mystic-silver': 'rgb(var(--mystic-silver) / <alpha-value>)',
-				
-				border: 'hsl(var(--border))',
-				input: 'hsl(var(--input))',
-				ring: 'hsl(var(--ring))',
-				background: 'hsl(var(--background))',
-				foreground: 'hsl(var(--foreground))',
-				primary: {
-					DEFAULT: 'rgb(var(--primary) / <alpha-value>)',
-					foreground: 'rgb(var(--primary-foreground) / <alpha-value>)'
-				},
-				secondary: {
-					DEFAULT: 'rgb(var(--secondary) / <alpha-value>)',
-					foreground: 'rgb(var(--secondary-foreground) / <alpha-value>)'
-				},
-				destructive: {
-					DEFAULT: 'hsl(var(--destructive))',
-					foreground: 'rgb(var(--destructive-foreground) / <alpha-value>)'
-				},
-				muted: {
-					DEFAULT: 'rgb(var(--muted) / <alpha-value>)',
-					foreground: 'rgb(var(--muted-foreground) / <alpha-value>)'
-				},
-				accent: {
-					DEFAULT: 'rgb(var(--accent) / <alpha-value>)',
-					foreground: 'rgb(var(--accent-foreground) / <alpha-value>)'
-				},
-				popover: {
-					DEFAULT: 'rgb(var(--popover) / <alpha-value>)',
-					foreground: 'rgb(var(--popover-foreground) / <alpha-value>)'
-				},
-				card: {
-					DEFAULT: 'rgb(var(--card) / <alpha-value>)',
-					foreground: 'rgb(var(--card-foreground) / <alpha-value>)'
-				}
-			},
-			fontFamily: {
-				'fantasy-title': ['Yeseva One', 'serif'],
-				'fantasy-header': ['Cormorant Garamond', 'serif'],
-				'fantasy-body': ['Jost', 'sans-serif'],
-			},
-			borderRadius: {
-				lg: 'var(--radius)',
-				md: 'calc(var(--radius) - 2px)',
-				sm: 'calc(var(--radius) - 4px)'
-			},
-			keyframes: {
-				'accordion-down': {
-					from: {
-						height: '0'
-					},
-					to: {
-						height: 'var(--radix-accordion-content-height)'
-					}
-				},
-				'accordion-up': {
-					from: {
-						height: 'var(--radix-accordion-content-height)'
-					},
-					to: {
-						height: '0'
-					}
-				}
-			},
-			animation: {
-				'accordion-down': 'accordion-down 0.2s ease-out',
-				'accordion-up': 'accordion-up 0.2s ease-out'
-			}
-		}
-	},
-	plugins: [require("tailwindcss-animate")],
+  darkMode: 'class',
+  content: [
+    './pages/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './app/**/*.{ts,tsx}',
+    './src/**/*.{ts,tsx}',
+  ],
+  prefix: '',
+  theme: {
+    container: {
+      center: true,
+      padding: '2rem',
+      screens: {
+        '2xl': '1400px',
+      },
+    },
+    extend: {
+      colors: {
+        'forest-green': 'rgb(var(--forest-green) / <alpha-value>)',
+        'aged-bronze': 'rgb(var(--aged-bronze) / <alpha-value>)',
+        'burnished-gold': 'rgb(var(--burnished-gold) / <alpha-value>)',
+        'saddle-leather': 'rgb(var(--saddle-leather) / <alpha-value>)',
+        parchment: 'rgb(var(--parchment) / <alpha-value>)',
+        'midnight-ink': 'rgb(var(--midnight-ink) / <alpha-value>)',
+        'mystic-silver': 'rgb(var(--mystic-silver) / <alpha-value>)',
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'rgb(var(--primary) / <alpha-value>)',
+          foreground: 'rgb(var(--primary-foreground) / <alpha-value>)',
+        },
+        secondary: {
+          DEFAULT: 'rgb(var(--secondary) / <alpha-value>)',
+          foreground: 'rgb(var(--secondary-foreground) / <alpha-value>)',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'rgb(var(--destructive-foreground) / <alpha-value>)',
+        },
+        muted: {
+          DEFAULT: 'rgb(var(--muted) / <alpha-value>)',
+          foreground: 'rgb(var(--muted-foreground) / <alpha-value>)',
+        },
+        accent: {
+          DEFAULT: 'rgb(var(--accent) / <alpha-value>)',
+          foreground: 'rgb(var(--accent-foreground) / <alpha-value>)',
+        },
+        popover: {
+          DEFAULT: 'rgb(var(--popover) / <alpha-value>)',
+          foreground: 'rgb(var(--popover-foreground) / <alpha-value>)',
+        },
+        card: {
+          DEFAULT: 'rgb(var(--card) / <alpha-value>)',
+          foreground: 'rgb(var(--card-foreground) / <alpha-value>)',
+        },
+      },
+      fontFamily: {
+        'fantasy-title': ['Yeseva One', 'serif'],
+        'fantasy-header': ['Cormorant Garamond', 'serif'],
+        'fantasy-body': ['Jost', 'sans-serif'],
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      keyframes: {
+        'accordion-down': {
+          from: { height: '0' },
+          to: { height: 'var(--radix-accordion-content-height)' },
+        },
+        'accordion-up': {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: '0' },
+        },
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out',
+      },
+    },
+  },
+  plugins: [require('tailwindcss-animate')],
 } satisfies Config;

--- a/packages/database/prismaClient.mjs
+++ b/packages/database/prismaClient.mjs
@@ -1,15 +1,13 @@
-// packages/database/prismaClient.mjs
 import dotenv from 'dotenv';
 import path from 'path';
-import { fileURLToPath, pathToFileURL } from 'url'; // Added pathToFileURL
+import { fileURLToPath, pathToFileURL } from 'url';
 
-// Ensure __dirname resolution works in ESM (Added)
+// Resolve __dirname in ESM
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Corrected dotenv path resolution
-// Assuming .env and env.test are in the 'backend' directory, relative to the monorepo root
-const backendDir = path.resolve(__dirname, '../../backend'); // Navigate up from packages/database to root, then to backend
+// Load environment variables from the backend directory
+const backendDir = path.resolve(__dirname, '../../backend');
 dotenv.config({
   path:
     process.env.NODE_ENV === 'test'
@@ -17,7 +15,7 @@ dotenv.config({
       : path.join(backendDir, '.env'),
 });
 
-// Dynamic import to handle CommonJS Prisma client in ESM environment
+// Dynamically import Prisma client
 const { PrismaClient } = await import('@prisma/client');
 
 let prisma = null;
@@ -25,27 +23,22 @@ let prisma = null;
 if (process.env.NODE_ENV === 'production') {
   prisma = new PrismaClient();
 } else {
-  // Use global to prevent multiple instances during development/hot reloads
   if (!global.__prisma) {
     global.__prisma = new PrismaClient();
   }
   prisma = global.__prisma;
 }
 
-// For tests: register for cleanup
-// Conditionally import and register for cleanup only if in a Jest environment
+// Register for cleanup when running Jest tests
 if (process.env.NODE_ENV === 'test' && process.env.JEST_WORKER_ID) {
   try {
-    // Dynamic import to prevent circular dependency
-    // Corrected path to jest.setup.mjs in the backend folder
     const jestSetupPath = path.resolve(__dirname, '../../backend/jest.setup.mjs');
-    const jestSetupURL = pathToFileURL(jestSetupPath).href; // Convert to file URL
-    const { registerPrismaForCleanup } = await import(jestSetupURL); // Use URL for import
+    const jestSetupURL = pathToFileURL(jestSetupPath).href;
+    const { registerPrismaForCleanup } = await import(jestSetupURL);
     registerPrismaForCleanup(prisma);
     console.info('[PrismaClient] Jest cleanup registered successfully.');
   } catch (err) {
     console.warn('[PrismaClient] Could not register for test cleanup:', err.message);
-    // Log the path it tried to import for easier debugging if it still fails
     const attemptedPath = path.resolve(__dirname, '../../backend/jest.setup.mjs');
     console.warn(`[PrismaClient] Attempted to import path: ${attemptedPath}`);
     if (
@@ -62,7 +55,5 @@ if (process.env.NODE_ENV === 'test' && process.env.JEST_WORKER_ID) {
     '[PrismaClient] Skipping Jest cleanup registration: Not in a Jest worker environment (JEST_WORKER_ID not set). This is expected when running standalone scripts with NODE_ENV=test.'
   );
 }
-
-console.info('[PrismaClient] Jest cleanup registered successfully.');
 
 export default prisma;


### PR DESCRIPTION
## Summary
- clean up toast imports and remove unused state in App component
- remove temporary console logging from auth controller
- reformat Tailwind config and streamline Prisma client setup
- drop stray leading blank line in Index page

## Testing
- `npm test` *(fails: Support for the experimental syntax 'jsx' isn't currently enabled)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689cefe077d48325afc5ad05026df344