### PR TITLE
refactor: align remaining files with ES module syntax

### DIFF
--- a/frontend/components/__tests__/TraitDisplay.test.js
+++ b/frontend/components/__tests__/TraitDisplay.test.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import TraitDisplay from '../TraitDisplay';
+import { View } from 'react-native';
 
 // Mock expo-linear-gradient
 jest.mock('expo-linear-gradient', () => ({
-  LinearGradient: ({ children, ...props }) => {
-    const { View } = require('react-native');
-    return <View {...props}>{children}</View>;
-  },
+  LinearGradient: ({ children, ...props }) => (
+    <View {...props}>{children}</View>
+  ),
 }));
 
 // Mock react-native components

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'tailwindcss';
+import tailwindcssAnimate from 'tailwindcss-animate';
 
 export default {
   darkMode: 'class',
@@ -86,5 +87,5 @@ export default {
       },
     },
   },
-  plugins: [require('tailwindcss-animate')],
+  plugins: [tailwindcssAnimate],
 } satisfies Config;

--- a/simple-test.js
+++ b/simple-test.js
@@ -1,2 +1,4 @@
 // Simple test file
-var x = 1
+const x = 1;
+
+export default x;

--- a/teardown.js
+++ b/teardown.js
@@ -1,4 +1,4 @@
-module.exports = async () => {
+export default async function teardown() {
   console.log('yeah bwoi!');
   process.exit(0);
-};
+}

--- a/tests/unit/example.test.js
+++ b/tests/unit/example.test.js
@@ -1,3 +1,5 @@
+import { test, expect } from '@jest/globals';
+
 test('Sample test works', () => {
   expect(1 + 1).toBe(2);
 });


### PR DESCRIPTION
## Summary
- convert root teardown script to ES module default export
- import tailwindcss-animate plugin via ESM and reference directly
- replace CommonJS `require` in TraitDisplay mock with ES import
- explicitly import Jest globals in example test and modernize sample script

## Testing
- `npm test` *(fails: Jest configuration missing for ESM/JSX)*

------
https://chatgpt.com/codex/tasks/task_e_689cff23701c8325865ac361047ddeba