### PR TITLE
refactor: camel case for training taskplan and traits

### DIFF
--- a/backend/examples/applyEpigeneticTraitsAtBirthExample.mjs
+++ b/backend/examples/applyEpigeneticTraitsAtBirthExample.mjs
@@ -27,7 +27,7 @@ const optimalResult = applyEpigeneticTraitsAtBirth({
 });
 
 console.log('Result:', JSON.stringify(optimalResult, null, 2));
-console.log('Expected: resilient and people_trusting traits\n');
+console.log('Expected: resilient and peopleTrusting traits\n');
 
 // Example 2: Inbreeding Scenario
 console.log('⚠️ Example 2: Inbreeding Scenario');
@@ -230,11 +230,11 @@ const edgeResult = applyEpigeneticTraitsAtBirth({
 });
 
 console.log('Result:', JSON.stringify(edgeResult, null, 2));
-console.log('Expected: resilient, people_trusting, and discipline_affinity_endurance\n');
+console.log('Expected: resilient, peopleTrusting, and discipline_affinity_endurance\n');
 
 console.log('✅ All examples completed!');
 console.log('\n📝 Key Usage Patterns:');
-console.log('- Low stress (≤20) + Premium feed (≥80) → resilient, people_trusting');
+console.log('- Low stress (≤20) + Premium feed (≥80) → resilient, peopleTrusting');
 console.log('- Inbreeding detected → fragile, reactive, low_immunity');
 console.log('- 3+ ancestors same discipline → discipline_affinity_*');
 console.log('- 4+ ancestors same discipline → legacy_talent chance');

--- a/backend/examples/horseTraitHelperUsage.mjs
+++ b/backend/examples/horseTraitHelperUsage.mjs
@@ -236,7 +236,7 @@ async function exampleCompleteWorkflow(horseId) {
 
     // 2. Check for specific traits
     console.log('\n2. Checking for specific traits:');
-    const importantTraits = ['resilient', 'bold', 'nervous', 'spooky', 'people_trusting'];
+    const importantTraits = ['resilient', 'bold', 'nervous', 'spooky', 'peopleTrusting'];
 
     for (const trait of importantTraits) {
       const hasTrait_ = await hasTrait(horseId, trait);

--- a/backend/test-connection.mjs
+++ b/backend/test-connection.mjs
@@ -5,18 +5,18 @@
  * with minimal mocking to focus on the core breeding trait calculation algorithms.
  *
  * 📋 BUSINESS RULES TESTED:
- * - Positive trait conditions: Low stress (≤20) + premium feed (≥80) → resilient, people_trusting
+ * - Positive trait conditions: Low stress (≤20) + premium feed (≥80) → resilient, peopleTrusting
  * - Negative trait conditions: Inbreeding (repeated ancestor IDs) → fragile, reactive, low_immunity
  * - Discipline specialization: 3+ ancestors same discipline → discipline_affinity_* traits
  * - Legacy talent: 4+ ancestors same discipline → legacy_talent trait
- * - Probability thresholds: resilient (75%), people_trusting (60%), discipline_affinity (70%), legacy_talent (40%)
+ * - Probability thresholds: resilient (75%), peopleTrusting (60%), discipline_affinity (70%), legacy_talent (40%)
  * - Inbreeding severity: High (4+ repeats), moderate (3 repeats), low (2 repeats)
  * - Random behavior: Deterministic testing with controlled Math.random() values
  * - Edge cases: Missing discipline fields, diverse lineage, no specialization
  *
  * 🎯 FUNCTIONALITY TESTED:
  * 1. applyEpigeneticTraitsAtBirth() - Core trait application logic with direct parameters
- * 2. Positive trait assignment: resilient and people_trusting with optimal conditions
+ * 2. Positive trait assignment: resilient and peopleTrusting with optimal conditions
  * 3. Negative trait assignment: fragile, reactive, low_immunity with inbreeding
  * 4. Discipline specialization: Racing, Dressage, Show Jumping affinity detection
  * 5. Legacy talent: Enhanced trait for strong discipline specialization
@@ -96,8 +96,8 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth Unit - Pure Logic Validati
       expect(result.negative).toEqual([]);
     });
 
-    it('should assign people_trusting trait when mare has low stress and premium feed', () => {
-      // Mock random to ensure trait assignment (below 0.60 threshold for people_trusting)
+    it('should assign peopleTrusting trait when mare has low stress and premium feed', () => {
+      // Mock random to ensure trait assignment (below 0.60 threshold for peopleTrusting)
       mockRandom.mockReturnValue(0.4);
 
       const mare = {
@@ -113,7 +113,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth Unit - Pure Logic Validati
         stressLevel: 20,
       });
 
-      expect(result.positive).toContain('people_trusting');
+      expect(result.positive).toContain('peopleTrusting');
       expect(result.negative).toEqual([]);
     });
 
@@ -121,7 +121,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth Unit - Pure Logic Validati
       // Mock random to ensure both traits are assigned
       mockRandom
         .mockReturnValueOnce(0.3) // Below 0.75 for resilient
-        .mockReturnValueOnce(0.2); // Below 0.60 for people_trusting
+        .mockReturnValueOnce(0.2); // Below 0.60 for peopleTrusting
 
       const mare = {
         id: 1,
@@ -137,7 +137,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth Unit - Pure Logic Validati
       });
 
       expect(result.positive).toContain('resilient');
-      expect(result.positive).toContain('people_trusting');
+      expect(result.positive).toContain('peopleTrusting');
       expect(result.negative).toEqual([]);
     });
 
@@ -158,7 +158,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth Unit - Pure Logic Validati
       });
 
       expect(result.positive).not.toContain('resilient');
-      expect(result.positive).not.toContain('people_trusting');
+      expect(result.positive).not.toContain('peopleTrusting');
     });
 
     it('should not assign positive traits when feed quality is too low', () => {
@@ -178,7 +178,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth Unit - Pure Logic Validati
       });
 
       expect(result.positive).not.toContain('resilient');
-      expect(result.positive).not.toContain('people_trusting');
+      expect(result.positive).not.toContain('peopleTrusting');
     });
   });
 
@@ -478,7 +478,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth Unit - Pure Logic Validati
       // Set specific random values for reproducible results
       mockRandom
         .mockReturnValueOnce(0.5) // resilient trait
-        .mockReturnValueOnce(0.4) // people_trusting trait
+        .mockReturnValueOnce(0.4) // peopleTrusting trait
         .mockReturnValueOnce(0.6) // discipline affinity trait
         .mockReturnValueOnce(0.3); // legacy talent trait
 
@@ -504,7 +504,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth Unit - Pure Logic Validati
 
       // Should get positive traits from optimal conditions and racing lineage
       expect(result.positive).toContain('resilient');
-      expect(result.positive).toContain('people_trusting');
+      expect(result.positive).toContain('peopleTrusting');
       expect(result.positive).toContain('discipline_affinity_racing');
       expect(result.positive).toContain('legacy_talent');
       expect(result.negative).toEqual([]);

--- a/backend/tests/applyEpigeneticTraitsAtBirth.test.mjs
+++ b/backend/tests/applyEpigeneticTraitsAtBirth.test.mjs
@@ -5,7 +5,7 @@
  * foal traits based on breeding conditions, lineage, and environmental factors.
  *
  * 📋 BUSINESS RULES TESTED:
- * - Environmental conditions: Low stress + premium feed → positive traits (resilient, people_trusting)
+ * - Environmental conditions: Low stress + premium feed → positive traits (resilient, peopleTrusting)
  * - Inbreeding detection: Common ancestors → negative traits (fragile, reactive, low_immunity)
  * - Discipline specialization: 3+ ancestors same discipline → discipline_affinity traits
  * - Legacy talent: 4+ ancestors same discipline → legacy_talent trait
@@ -106,7 +106,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth - Breeding Condition Analy
       expect(result.positive).toContain('resilient');
     });
 
-    it('should assign people_trusting trait with low stress and premium feed', () => {
+    it('should assign peopleTrusting trait with low stress and premium feed', () => {
       jest.spyOn(Math, 'random').mockReturnValue(0.4); // Below 0.60 threshold
 
       const mare = { stressLevel: 20 };
@@ -116,7 +116,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth - Breeding Condition Analy
         stressLevel: 20,
       });
 
-      expect(result.positive).toContain('people_trusting');
+      expect(result.positive).toContain('peopleTrusting');
     });
 
     it('should not assign positive traits with high stress', () => {
@@ -128,7 +128,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth - Breeding Condition Analy
       });
 
       expect(result.positive).not.toContain('resilient');
-      expect(result.positive).not.toContain('people_trusting');
+      expect(result.positive).not.toContain('peopleTrusting');
     });
 
     it('should not assign positive traits with poor feed quality', () => {
@@ -140,7 +140,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth - Breeding Condition Analy
       });
 
       expect(result.positive).not.toContain('resilient');
-      expect(result.positive).not.toContain('people_trusting');
+      expect(result.positive).not.toContain('peopleTrusting');
     });
   });
 

--- a/backend/tests/applyEpigeneticTraitsAtBirthUnit.test.mjs
+++ b/backend/tests/applyEpigeneticTraitsAtBirthUnit.test.mjs
@@ -5,18 +5,18 @@
  * with minimal mocking to focus on the core breeding trait calculation algorithms.
  *
  * 📋 BUSINESS RULES TESTED:
- * - Positive trait conditions: Low stress (≤20) + premium feed (≥80) → resilient, people_trusting
+ * - Positive trait conditions: Low stress (≤20) + premium feed (≥80) → resilient, peopleTrusting
  * - Negative trait conditions: Inbreeding (repeated ancestor IDs) → fragile, reactive, low_immunity
  * - Discipline specialization: 3+ ancestors same discipline → discipline_affinity_* traits
  * - Legacy talent: 4+ ancestors same discipline → legacy_talent trait
- * - Probability thresholds: resilient (75%), people_trusting (60%), discipline_affinity (70%), legacy_talent (40%)
+ * - Probability thresholds: resilient (75%), peopleTrusting (60%), discipline_affinity (70%), legacy_talent (40%)
  * - Inbreeding severity: High (4+ repeats), moderate (3 repeats), low (2 repeats)
  * - Random behavior: Deterministic testing with controlled Math.random() values
  * - Edge cases: Missing discipline fields, diverse lineage, no specialization
  *
  * 🎯 FUNCTIONALITY TESTED:
  * 1. applyEpigeneticTraitsAtBirth() - Core trait application logic with direct parameters
- * 2. Positive trait assignment: resilient and people_trusting with optimal conditions
+ * 2. Positive trait assignment: resilient and peopleTrusting with optimal conditions
  * 3. Negative trait assignment: fragile, reactive, low_immunity with inbreeding
  * 4. Discipline specialization: Racing, Dressage, Show Jumping affinity detection
  * 5. Legacy talent: Enhanced trait for strong discipline specialization
@@ -94,8 +94,8 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth Unit - Pure Logic Validati
       expect(result.negative).toEqual([]);
     });
 
-    it('should assign people_trusting trait when mare has low stress and premium feed', () => {
-      // Mock random to ensure trait assignment (below 0.60 threshold for people_trusting)
+    it('should assign peopleTrusting trait when mare has low stress and premium feed', () => {
+      // Mock random to ensure trait assignment (below 0.60 threshold for peopleTrusting)
       mockRandom.mockReturnValue(0.4);
 
       const mare = {
@@ -111,7 +111,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth Unit - Pure Logic Validati
         stressLevel: 20,
       });
 
-      expect(result.positive).toContain('people_trusting');
+      expect(result.positive).toContain('peopleTrusting');
       expect(result.negative).toEqual([]);
     });
 
@@ -119,7 +119,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth Unit - Pure Logic Validati
       // Mock random to ensure both traits are assigned
       mockRandom
         .mockReturnValueOnce(0.3) // Below 0.75 for resilient
-        .mockReturnValueOnce(0.2); // Below 0.60 for people_trusting
+        .mockReturnValueOnce(0.2); // Below 0.60 for peopleTrusting
 
       const mare = {
         id: 1,
@@ -135,7 +135,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth Unit - Pure Logic Validati
       });
 
       expect(result.positive).toContain('resilient');
-      expect(result.positive).toContain('people_trusting');
+      expect(result.positive).toContain('peopleTrusting');
       expect(result.negative).toEqual([]);
     });
 
@@ -156,7 +156,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth Unit - Pure Logic Validati
       });
 
       expect(result.positive).not.toContain('resilient');
-      expect(result.positive).not.toContain('people_trusting');
+      expect(result.positive).not.toContain('peopleTrusting');
     });
 
     it('should not assign positive traits when feed quality is too low', () => {
@@ -176,7 +176,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth Unit - Pure Logic Validati
       });
 
       expect(result.positive).not.toContain('resilient');
-      expect(result.positive).not.toContain('people_trusting');
+      expect(result.positive).not.toContain('peopleTrusting');
     });
   });
 
@@ -472,7 +472,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth Unit - Pure Logic Validati
       // Set specific random values for reproducible results
       mockRandom
         .mockReturnValueOnce(0.5) // resilient trait
-        .mockReturnValueOnce(0.4) // people_trusting trait
+        .mockReturnValueOnce(0.4) // peopleTrusting trait
         .mockReturnValueOnce(0.6) // discipline affinity trait
         .mockReturnValueOnce(0.3); // legacy talent trait
 
@@ -498,7 +498,7 @@ describe('🧬 UNIT: Apply Epigenetic Traits At Birth Unit - Pure Logic Validati
 
       // Should get positive traits from optimal conditions and racing lineage
       expect(result.positive).toContain('resilient');
-      expect(result.positive).toContain('people_trusting');
+      expect(result.positive).toContain('peopleTrusting');
       expect(result.positive).toContain('discipline_affinity_racing');
       expect(result.positive).toContain('legacy_talent');
       expect(result.negative).toEqual([]);

--- a/backend/tests/integration/competitionWorkflow.integration.test.mjs
+++ b/backend/tests/integration/competitionWorkflow.integration.test.mjs
@@ -133,7 +133,7 @@ describe('🏆 INTEGRATION: Complete Competition Workflow', () => {
             'Cross Country': 70,
           },
           epigeneticModifiers: {
-            positive: ['fast', 'athletic', 'focused', 'brave', 'resilient', 'people_trusting'],
+            positive: ['fast', 'athletic', 'focused', 'brave', 'resilient', 'peopleTrusting'],
             negative: [],
             hidden: ['champion_heart'],
           },

--- a/backend/tests/integration/horseBreedingWorkflow.integration.test.mjs
+++ b/backend/tests/integration/horseBreedingWorkflow.integration.test.mjs
@@ -173,7 +173,7 @@ describe('🐎 INTEGRATION: Complete Horse Breeding Workflow', () => {
             'Show Jumping': 82,
           },
           epigeneticModifiers: {
-            positive: ['powerful', 'brave', 'athletic', 'people_trusting'],
+            positive: ['powerful', 'brave', 'athletic', 'peopleTrusting'],
             negative: [],
             hidden: ['endurance'],
           },

--- a/backend/tests/utils/epigeneticTraits.comprehensive.test.mjs
+++ b/backend/tests/utils/epigeneticTraits.comprehensive.test.mjs
@@ -111,7 +111,7 @@ describe('🧬 COMPREHENSIVE: Epigenetic Traits Calculation System', () => {
 
     it('should handle high bonding score scenarios', () => {
       const params = {
-        damTraits: ['resilient', 'people_trusting'],
+        damTraits: ['resilient', 'peopleTrusting'],
         sireTraits: ['calm', 'intelligent'],
         damBondScore: 95, // Very high bonding
         damStressLevel: 20,

--- a/backend/utils/applyEpigeneticTraitsAtBirth.mjs
+++ b/backend/utils/applyEpigeneticTraitsAtBirth.mjs
@@ -47,11 +47,11 @@ export function applyEpigeneticTraitsAtBirth({ mare, lineage, feedQuality, stres
         );
       }
 
-      // Good chance for people_trusting trait
+      // Good chance for peopleTrusting trait
       if (Math.random() < 0.6) {
-        positive.push('people_trusting');
+        positive.push('peopleTrusting');
         logger.info(
-          '[applyEpigeneticTraitsAtBirth] Applied people_trusting trait (low stress + premium feed)',
+          '[applyEpigeneticTraitsAtBirth] Applied peopleTrusting trait (low stress + premium feed)',
         );
       }
     }

--- a/backend/utils/competitionLogic.mjs
+++ b/backend/utils/competitionLogic.mjs
@@ -46,7 +46,7 @@ export function calculateCompetitionScore(disciplineScore, traits, age, discipli
     const disciplineConfig = {
       'Western Pleasure': {
         stats: ['focus', 'obedience', 'intelligence'],
-        beneficial: ['calm', 'people_trusting', 'focused', 'intelligent'],
+        beneficial: ['calm', 'peopleTrusting', 'focused', 'intelligent'],
         detrimental: ['nervous', 'aggressive', 'stubborn'],
       },
       Reining: {
@@ -86,7 +86,7 @@ export function calculateCompetitionScore(disciplineScore, traits, age, discipli
       },
       Saddleseat: {
         stats: ['flexibility', 'balance', 'obedience'],
-        beneficial: ['flexible', 'balanced', 'people_trusting', 'focused'],
+        beneficial: ['flexible', 'balanced', 'peopleTrusting', 'focused'],
         detrimental: ['stiff', 'clumsy', 'stubborn'],
       },
       Endurance: {
@@ -101,7 +101,7 @@ export function calculateCompetitionScore(disciplineScore, traits, age, discipli
       },
       Dressage: {
         stats: ['precision', 'focus', 'obedience'],
-        beneficial: ['focused', 'intelligent', 'calm', 'people_trusting'],
+        beneficial: ['focused', 'intelligent', 'calm', 'peopleTrusting'],
         detrimental: ['nervous', 'aggressive', 'stubborn'],
       },
       'Show Jumping': {
@@ -111,7 +111,7 @@ export function calculateCompetitionScore(disciplineScore, traits, age, discipli
       },
       Vaulting: {
         stats: ['flexibility', 'balance', 'obedience'],
-        beneficial: ['flexible', 'balanced', 'calm', 'people_trusting'],
+        beneficial: ['flexible', 'balanced', 'calm', 'peopleTrusting'],
         detrimental: ['stiff', 'nervous', 'aggressive'],
       },
       Polo: {
@@ -126,7 +126,7 @@ export function calculateCompetitionScore(disciplineScore, traits, age, discipli
       },
       'Combined Driving': {
         stats: ['obedience', 'stamina', 'focus'],
-        beneficial: ['people_trusting', 'resilient', 'focused', 'intelligent'],
+        beneficial: ['peopleTrusting', 'resilient', 'focused', 'intelligent'],
         detrimental: ['stubborn', 'nervous', 'weak'],
       },
       'Fine Harness': {
@@ -162,7 +162,7 @@ export function calculateCompetitionScore(disciplineScore, traits, age, discipli
       },
       'Obedience Training': {
         stats: ['obedience', 'precision', 'intelligence'],
-        beneficial: ['people_trusting', 'intelligent', 'focused', 'calm'],
+        beneficial: ['peopleTrusting', 'intelligent', 'focused', 'calm'],
         detrimental: ['stubborn', 'aggressive', 'nervous'],
       },
     };
@@ -299,7 +299,7 @@ function getDisciplineConfigurations() {
   return {
     'Western Pleasure': {
       stats: ['obedience', 'focus', 'precision'],
-      beneficial: ['calm', 'people_trusting', 'focused', 'intelligent'],
+      beneficial: ['calm', 'peopleTrusting', 'focused', 'intelligent'],
       detrimental: ['nervous', 'aggressive', 'stubborn'],
     },
     Reining: {
@@ -339,7 +339,7 @@ function getDisciplineConfigurations() {
     },
     Saddleseat: {
       stats: ['flexibility', 'obedience', 'precision'],
-      beneficial: ['flexible', 'balanced', 'people_trusting', 'focused'],
+      beneficial: ['flexible', 'balanced', 'peopleTrusting', 'focused'],
       detrimental: ['stiff', 'clumsy', 'stubborn'],
     },
     Endurance: {
@@ -354,7 +354,7 @@ function getDisciplineConfigurations() {
     },
     Dressage: {
       stats: ['precision', 'obedience', 'focus'],
-      beneficial: ['focused', 'intelligent', 'calm', 'people_trusting'],
+      beneficial: ['focused', 'intelligent', 'calm', 'peopleTrusting'],
       detrimental: ['nervous', 'aggressive', 'stubborn'],
     },
     'Show Jumping': {
@@ -364,7 +364,7 @@ function getDisciplineConfigurations() {
     },
     Vaulting: {
       stats: ['strength', 'flexibility', 'endurance'],
-      beneficial: ['flexible', 'balanced', 'calm', 'people_trusting'],
+      beneficial: ['flexible', 'balanced', 'calm', 'peopleTrusting'],
       detrimental: ['stiff', 'nervous', 'aggressive'],
     },
     Polo: {
@@ -379,7 +379,7 @@ function getDisciplineConfigurations() {
     },
     'Combined Driving': {
       stats: ['obedience', 'strength', 'focus'],
-      beneficial: ['people_trusting', 'resilient', 'focused', 'intelligent'],
+      beneficial: ['peopleTrusting', 'resilient', 'focused', 'intelligent'],
       detrimental: ['stubborn', 'nervous', 'weak'],
     },
     'Fine Harness': {
@@ -415,7 +415,7 @@ function getDisciplineConfigurations() {
     },
     'Obedience Training': {
       stats: ['obedience', 'precision', 'intelligence'],
-      beneficial: ['people_trusting', 'intelligent', 'focused', 'calm'],
+      beneficial: ['peopleTrusting', 'intelligent', 'focused', 'calm'],
       detrimental: ['stubborn', 'aggressive', 'nervous'],
     },
   };

--- a/backend/utils/traitEffects.mjs
+++ b/backend/utils/traitEffects.mjs
@@ -212,7 +212,7 @@ const traitEffects = {
     description: 'Benefits from specialized bloodline heritage',
   },
 
-  people_trusting: {
+  peopleTrusting: {
     // Bonding effects
     bondingBonus: 0.3, // 30% faster bonding with humans
     handlerCompatibility: 0.25, // 25% better handler relationships

--- a/training-system-taskplan.mjs
+++ b/training-system-taskplan.mjs
@@ -5,7 +5,7 @@
  * and provides a structured approach for any future enhancements or maintenance tasks.
  */
 
-export const TRAINING_SYSTEM_TASKS = {
+export const trainingSystemTasks = {
   // ✅ COMPLETED IMPLEMENTATION
   completed: {
     coreSystem: {
@@ -29,7 +29,7 @@ export const TRAINING_SYSTEM_TASKS = {
         "backend/constants/schema.mjs",
         "backend/controllers/trainingController.mjs"
       ],
-      implementation: "TRAINING_LIMITS constants with MIN_AGE: 3, MAX_AGE: 20, COOLDOWN_DAYS: 7",
+      implementation: "trainingLimits constants with minAge: 3, maxAge: 20, cooldownDays: 7",
       testResults: "Age validation tests passing in trainingController.test.mjs",
       status: "COMPLETE"
     },
@@ -289,20 +289,20 @@ export const TRAINING_SYSTEM_TASKS = {
 /**
  * Export implementation status for tracking
  */
-export const TRAINING_SYSTEM_STATUS = {
+export const trainingSystemStatus = {
   totalComponents: 10,
   completedComponents: 10,
   completionPercentage: 100,
   totalDisciplines: 23,
   maintenanceTasks: 2,
   enhancementTasks: 4,
-  overallStatus: "PRODUCTION_READY"
+  overallStatus: "productionReady"
 };
 
 /**
  * Export API endpoints for frontend integration
  */
-export const TRAINING_API_ENDPOINTS = {
+export const trainingApiEndpoints = {
   trainHorse: "POST /api/training/train",
   getTrainingStatus: "GET /api/training/status/:horseId/:discipline",
   getAllTrainingStatuses: "GET /api/training/status/:horseId",
@@ -314,11 +314,11 @@ export const TRAINING_API_ENDPOINTS = {
 /**
  * Export database schema requirements
  */
-export const TRAINING_DATABASE_SCHEMA = {
+export const trainingDatabaseSchema = {
   horseFields: [
     "disciplineScores (JSON) - Stores score per discipline",
     "trainingCooldown (DateTime) - Next eligible training date",
-    "epigenetic_modifiers (JSON) - Traits affecting training",
+    "epigeneticModifiers (JSON) - Traits affecting training",
     "stats (Individual fields) - Speed, stamina, agility, etc."
   ],
   trainingLogFields: [
@@ -330,4 +330,4 @@ export const TRAINING_DATABASE_SCHEMA = {
   ]
 };
 
-export default TRAINING_SYSTEM_TASKS;
+export default trainingSystemTasks;


### PR DESCRIPTION
## Summary
- refactor training-system-taskplan to use camelCase and remove snake_case references
- rename people_trusting trait to peopleTrusting across utilities, examples, and tests

## Testing
- `npm test` *(fails: Support for the experimental syntax 'jsx' isn't currently enabled)*

------
https://chatgpt.com/codex/tasks/task_e_689cffa8b5948325b4475e0b5644a1e1