### PR TITLE
fix(auth): rate-limit onboarding endpoints (CodeQL #190)

### DIFF
--- a/backend/modules/auth/routes/authRoutes.mjs
+++ b/backend/modules/auth/routes/authRoutes.mjs
@@ -727,13 +727,23 @@ router.get('/verification-status', authenticateToken, authController.getVerifica
  * POST /api/auth/complete-onboarding
  * Marks authenticated user's onboarding as complete in User.settings.
  */
-router.post('/complete-onboarding', authenticateToken, authController.completeOnboarding);
+router.post(
+  '/complete-onboarding',
+  profileRateLimiter,
+  authenticateToken,
+  authController.completeOnboarding,
+);
 
 /**
  * POST /api/auth/advance-onboarding
  * Increments the user's onboarding step. Sets completedOnboarding: true at step 10.
  */
-router.post('/advance-onboarding', authenticateToken, authController.advanceOnboarding);
+router.post(
+  '/advance-onboarding',
+  profileRateLimiter,
+  authenticateToken,
+  authController.advanceOnboarding,
+);
 
 /**
  * PATCH /api/auth/profile/preferences


### PR DESCRIPTION
## Summary

Closes CodeQL high-severity alert **#190** (\`js/missing-rate-limiting\`) introduced when Epic 21S landed in PR #66. Adds \`profileRateLimiter\` in front of the two onboarding mutation endpoints so they match the rate-limit pattern the rest of the auth router already uses.

## Changes

- \`POST /api/auth/advance-onboarding\` (line 736) — the flagged endpoint
- \`POST /api/auth/complete-onboarding\` (line 730) — same risk surface, not flagged yet but fixing it now to stay consistent and avoid CodeQL flagging it on the next scan

Both now use the same \`profileRateLimiter, authenticateToken\` ordering as \`PATCH /api/auth/profile/preferences\` (line 745, landed by 21S-5).

## Verification

- CodeQL rule \`js/missing-rate-limiting\` scans for authenticated route handlers without a rate-limit middleware upstream. After this change the rule should not flag either endpoint.
- No test changes needed — \`profileRateLimiter\` passes transparently under \`NODE_ENV=test\`.

## Test plan

- [ ] CI CodeQL job: re-run on this PR should close alert #190 and not flag \`/complete-onboarding\`
- [ ] Existing onboarding suites still pass (\`backend/modules/auth/__tests__/\` + \`tests/integration/onboarding*\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied rate limiting safeguards to authentication endpoints involved in user onboarding workflows to enhance API stability and protect against potential abuse patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->