### PR TITLE
feat(marketplace): store-bought horses arrive unvetted

### DIFF
--- a/backend/modules/marketplace/controllers/marketplaceController.mjs
+++ b/backend/modules/marketplace/controllers/marketplaceController.mjs
@@ -490,7 +490,7 @@ export async function buyStoreHorse(req, res) {
     const dateOfBirth = new Date();
     dateOfBirth.setFullYear(dateOfBirth.getFullYear() - 3);
 
-    const newHorse = await createHorse({
+    const createdHorse = await createHorse({
       name: horseName,
       breedId: parsedBreedId,
       sex,
@@ -499,6 +499,19 @@ export async function buyStoreHorse(req, res) {
       userId: buyerId,
       healthStatus: 'Excellent',
       ...stats,
+    });
+
+    // Store-bought horses arrive unvetted — the player must book a vet
+    // check before the "Vetted" care chip turns green.
+    //
+    // The horse schema defaults `lastVettedDate` to `now()` and
+    // createHorse() filters out falsy inputs (`...(lastVettedDate && ...)`),
+    // so passing `lastVettedDate: null` to createHorse is silently a
+    // no-op. Explicit follow-up update is the clean fix that doesn't
+    // touch the shared createHorse contract.
+    const newHorse = await prisma.horse.update({
+      where: { id: createdHorse.id },
+      data: { lastVettedDate: null },
     });
 
     logger.info(


### PR DESCRIPTION
## Summary

Product rule: horses purchased from the Horse Trader should NOT arrive already vetted. The player has to book a vet check themselves before the \"Vetted\" care chip turns green.

## Root cause

- Prisma schema: `horse.lastVettedDate DateTime? @default(now())` — every new horse defaults to \"vetted today\"
- `buyStoreHorse` in `backend/modules/marketplace/controllers/marketplaceController.mjs` did not override the default
- Frontend `CareChip` label=\"Vetted\" reads `lastVettedDate` via `careChipStatus(...)`, so every store-bought horse displayed as \"fully vetted\" the moment it entered the buyer's stable

## Fix

After `createHorse(...)` in `buyStoreHorse`, run an explicit `prisma.horse.update({ lastVettedDate: null })`.

**Why not pass `lastVettedDate: null` to `createHorse`?** Its spread guard filters out falsy values (`...(lastVettedDate && { lastVettedDate: new Date(...) })`), so null is silently ignored and Prisma's schema default `now()` still applies. The explicit follow-up update is the clean fix that doesn't touch the shared `createHorse` contract used by breeding, admin, and test fixture flows.

## No frontend change needed

`frontend/src/lib/utils/care-status-utils.ts::careChipStatus(null, 7, 14)` already returns `'bad'`, which renders the chip red. Contract already handled.

## Scope

- Affects ONLY the Horse Trader / store purchase flow (`POST /api/v1/marketplace/store/buy`)
- Does NOT touch breeding foals, admin creates, or any test fixture
- Does NOT change the schema default (still `now()` — that default is correct for all other creation paths)

## Test plan

- [x] `node --check` passes
- [ ] Buy a 3-year-old from the Horse Trader → horse appears in stable with red/bad Vetted chip
- [ ] Book a vet check on that horse → chip flips to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)