### PR TITLE
chore(tests): Phase 3a — eliminate Date.now() fixture-name collisions

### DIFF
--- a/backend/__tests__/conformationApiEndpoints.test.mjs
+++ b/backend/__tests__/conformationApiEndpoints.test.mjs
@@ -23,7 +23,7 @@ const { CONFORMATION_REGIONS } = await import('../modules/horses/services/confor
 const { getBreedProfile } = await import('../modules/horses/data/breedProfileLoader.mjs');
 
 // ── Test data setup ────────────────────────────────────────────────────────
-const ts = `${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+const ts = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).slice(2, 7)}`;
 let testUser;
 let testBreed;
 const createdHorseIds = [];
@@ -49,7 +49,7 @@ const BASE_SCORES = {
 async function seedHorse(scores) {
   const horse = await prisma.horse.create({
     data: {
-      name: `ConfApiTest_${Date.now()}_${Math.random().toString(36).slice(2, 5)}`,
+      name: `ConfApiTest_${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).slice(2, 5)}`,
       sex: 'Mare',
       dateOfBirth: new Date('2020-01-01'),
       age: 4,

--- a/backend/__tests__/integration/advance-onboarding.test.mjs
+++ b/backend/__tests__/integration/advance-onboarding.test.mjs
@@ -26,8 +26,8 @@ describe('POST /api/auth/advance-onboarding', () => {
   // compatibility with existing .set(rateLimitBypassHeader) call sites.
   const rateLimitBypassHeader = {};
   const testUserData = {
-    username: `advanceonboard_${Date.now()}`,
-    email: `advanceonboard_${Date.now()}@example.com`,
+    username: `advanceonboard_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+    email: `advanceonboard_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
     password: 'TestPassword123!',
     firstName: 'Advance',
     lastName: 'Onboard',

--- a/backend/__tests__/integration/auth-cookies.test.mjs
+++ b/backend/__tests__/integration/auth-cookies.test.mjs
@@ -78,8 +78,8 @@ describe('Authentication with HttpOnly Cookies', () => {
     it('should set httpOnly cookies on successful registration', async () => {
       const registrationUser = {
         ...testUserData,
-        email: `cookietest+${Date.now()}@example.com`,
-        username: `cookietest${Date.now()}`,
+        email: `cookietest+${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
+        username: `cookietest${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
       };
       const response = await request(app)
         .post('/api/auth/register')

--- a/backend/__tests__/integration/auth-password-reset.test.mjs
+++ b/backend/__tests__/integration/auth-password-reset.test.mjs
@@ -153,7 +153,7 @@ describe('Auth — Password Reset Integration', () => {
     const resetRes = await request(app)
       .post('/auth/forgot-password')
       .set('Origin', 'http://localhost:3000')
-      .send({ email: `nonexistent_${Date.now()}@example.com` });
+      .send({ email: `nonexistent_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com` });
 
     // Must NOT reveal whether the account exists
     expect(resetRes.status).toBe(200);

--- a/backend/__tests__/integration/authenticated-auth-routes-csrf.test.mjs
+++ b/backend/__tests__/integration/authenticated-auth-routes-csrf.test.mjs
@@ -49,7 +49,7 @@ describe('authenticated auth routes — CSRF enforcement canary', () => {
   });
 
   beforeEach(async () => {
-    const unique = `${Date.now()}${Math.floor(Math.random() * 10000)}`;
+    const unique = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}${Math.floor(Math.random() * 10000)}`;
     const email = `${PREFIX}${unique}@test.com`;
     const username = `${PREFIX}${unique}`;
 

--- a/backend/__tests__/integration/caching-circuit-breaker.test.mjs
+++ b/backend/__tests__/integration/caching-circuit-breaker.test.mjs
@@ -202,7 +202,7 @@ describe('Caching Circuit Breaker Integration Tests', () => {
     });
 
     it('should invalidate cache by pattern', async () => {
-      const prefix = `test:pattern:${Date.now()}`;
+      const prefix = `test:pattern:${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
       const key1 = generateCacheKey(prefix, 'item1');
       const key2 = generateCacheKey(prefix, 'item2');
       const key3 = generateCacheKey('different', 'item');

--- a/backend/__tests__/integration/crossSystemValidation.test.mjs
+++ b/backend/__tests__/integration/crossSystemValidation.test.mjs
@@ -286,7 +286,7 @@ describe('Cross-System Validation Tests', () => {
       // Create show directly in database (no API endpoint exists)
       const testShow = await prisma.show.create({
         data: {
-          name: `Cross System Test Show ${Date.now()}`,
+          name: `Cross System Test Show ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           runDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
           discipline: 'Racing',
           levelMin: 1,

--- a/backend/__tests__/integration/csrf-integration.test.mjs
+++ b/backend/__tests__/integration/csrf-integration.test.mjs
@@ -51,7 +51,7 @@ describe('CSRF protection — real browser flow', () => {
   });
 
   beforeEach(async () => {
-    const unique = `${Date.now()}${Math.floor(Math.random() * 10000)}`;
+    const unique = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}${Math.floor(Math.random() * 10000)}`;
     const email = `${TEST_EMAIL_PREFIX}${unique}@test.com`;
     const username = `${TEST_EMAIL_PREFIX}${unique}`;
 

--- a/backend/__tests__/integration/email-verification.test.mjs
+++ b/backend/__tests__/integration/email-verification.test.mjs
@@ -431,7 +431,10 @@ describe('Email Verification System - Integration Tests', () => {
       const os = await import('os');
       const path = await import('path');
       const fs = await import('fs');
-      emailCapturePath = path.join(os.tmpdir(), `email-capture-${Date.now()}-${Math.random()}.jsonl`);
+      emailCapturePath = path.join(
+        os.tmpdir(),
+        `email-capture-${Date.now()}_${Math.random().toString(36).slice(2, 6)}-${Math.random()}.jsonl`,
+      );
       process.env.EMAIL_CAPTURE_FILE = emailCapturePath;
       capturedVerificationTokens = () => {
         if (!fs.existsSync(emailCapturePath)) {

--- a/backend/__tests__/integration/input-validation.test.mjs
+++ b/backend/__tests__/integration/input-validation.test.mjs
@@ -54,8 +54,8 @@ describe('Input Validation Integration Tests', () => {
           .post('/api/auth/register')
           .set('Origin', 'http://localhost:3000')
           .send({
-            email: `valid${Date.now()}@example.com`,
-            username: `testuser${Date.now()}`,
+            email: `valid${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
+            username: `testuser${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             password: 'ValidPass123!',
             firstName: 'Test',
             lastName: 'User',
@@ -157,8 +157,8 @@ describe('Input Validation Integration Tests', () => {
           .post('/api/auth/register')
           .set('Origin', 'http://localhost:3000')
           .send({
-            email: `test${Date.now()}@example.com`,
-            username: `testuser${Date.now()}`,
+            email: `test${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
+            username: `testuser${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             password: 'ValidPass123!',
             firstName: 'Test',
             lastName: 'User',
@@ -176,8 +176,8 @@ describe('Input Validation Integration Tests', () => {
             .post('/api/auth/register')
             .set('Origin', 'http://localhost:3000')
             .send({
-              email: `test${Date.now()}@example.com`,
-              username: `testuser${Date.now()}`,
+              email: `test${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
+              username: `testuser${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
               password: `ValidPass123${char}`,
               firstName: 'Test',
               lastName: 'User',
@@ -240,8 +240,8 @@ describe('Input Validation Integration Tests', () => {
           .post('/api/auth/register')
           .set('Origin', 'http://localhost:3000')
           .send({
-            email: `test${Date.now()}@example.com`,
-            username: `test_user_${Date.now()}`,
+            email: `test${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
+            username: `test_user_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             password: 'ValidPass123!',
             firstName: 'Test',
             lastName: 'User',

--- a/backend/__tests__/integration/rate-limiting.test.mjs
+++ b/backend/__tests__/integration/rate-limiting.test.mjs
@@ -300,8 +300,8 @@ describe('Rate Limiting System', () => {
         .set('X-Forwarded-For', ip)
         .send({
           ...baseData,
-          email: `reg_unique_${Date.now()}@example.com`,
-          username: `reguser_unique_${Date.now()}`,
+          email: `reg_unique_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
+          username: `reguser_unique_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         });
 
       expectRateLimitExceeded(response);

--- a/backend/__tests__/integration/security-attack-simulation.test.mjs
+++ b/backend/__tests__/integration/security-attack-simulation.test.mjs
@@ -259,8 +259,8 @@ describe('Security Attack Simulation Tests', () => {
               .post('/api/auth/register')
               .set('Origin', 'http://localhost:3000')
               .send({
-                email: `attacker${Date.now()}_${i}@evil.com`,
-                username: `attacker${Date.now()}_${i}`,
+                email: `attacker${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${i}@evil.com`,
+                username: `attacker${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${i}`,
                 password: 'EvilPass123!',
                 firstName: 'Evil',
                 lastName: 'Attacker',
@@ -332,7 +332,7 @@ describe('Security Attack Simulation Tests', () => {
               .set('Origin', 'http://localhost:3000')
               .set('Authorization', `Bearer ${attackerToken}`)
               .send({
-                username: `newname${Date.now()}_${i}`,
+                username: `newname${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${i}`,
               }),
           );
         }
@@ -458,8 +458,8 @@ describe('Security Attack Simulation Tests', () => {
           .post('/api/auth/register')
           .set('Origin', 'http://localhost:3000')
           .send({
-            email: `test${Date.now()}@example.com`,
-            username: `testuser${Date.now()}`,
+            email: `test${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
+            username: `testuser${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             password: 'ValidPass123!',
             firstName: '<script>alert(1)</script>',
             lastName: '<img src=x onerror=alert(1)>',

--- a/backend/__tests__/integration/security/auth-bypass-attempts.test.mjs
+++ b/backend/__tests__/integration/security/auth-bypass-attempts.test.mjs
@@ -45,8 +45,8 @@ describe('Authentication Bypass Attempts Integration Tests', () => {
     // Create test user in database
     testUser = await prisma.user.create({
       data: {
-        email: `test-${Date.now()}-${Math.random().toString(36).substring(7)}@example.com`,
-        username: `testuser-${Date.now()}-${Math.random().toString(36).substring(7)}`,
+        email: `test-${Date.now()}_${Math.random().toString(36).slice(2, 6)}-${Math.random().toString(36).substring(7)}@example.com`,
+        username: `testuser-${Date.now()}_${Math.random().toString(36).slice(2, 6)}-${Math.random().toString(36).substring(7)}`,
         password: 'hashedPassword123', // Mock hashed password
         firstName: 'Test',
         lastName: 'User',
@@ -414,8 +414,8 @@ describe('Authentication Bypass Attempts Integration Tests', () => {
       // Create second user
       const userB = await prisma.user.create({
         data: {
-          email: `testB-${Date.now()}@example.com`,
-          username: `testuserB-${Date.now()}`,
+          email: `testB-${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
+          username: `testuserB-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           password: 'hashedPassword123',
           firstName: 'Test',
           lastName: 'UserB',

--- a/backend/__tests__/integration/security/owasp-comprehensive.test.mjs
+++ b/backend/__tests__/integration/security/owasp-comprehensive.test.mjs
@@ -50,8 +50,8 @@ describe('🔒 OWASP Top 10 - Comprehensive Security Tests', () => {
     const hashedPassword = await bcrypt.hash('TestPassword123!', 12);
     testUser = await prisma.user.create({
       data: {
-        username: `owasp-test-user-${Date.now()}`,
-        email: `owasp-test-${Date.now()}@test.com`,
+        username: `owasp-test-user-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `owasp-test-${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
         password: hashedPassword,
         role: 'user',
         firstName: 'OWASP',
@@ -428,8 +428,8 @@ describe('🔒 OWASP Top 10 - Comprehensive Security Tests', () => {
         // Create another user's horse
         const otherUser = await prisma.user.create({
           data: {
-            username: `otheruser${Date.now()}`,
-            email: `other-${Date.now()}@test.com`,
+            username: `otheruser${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+            email: `other-${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
             password: await bcrypt.hash('TestPassword123!', 12),
             firstName: 'Other',
             lastName: 'User',

--- a/backend/__tests__/integration/security/ownership-violations.test.mjs
+++ b/backend/__tests__/integration/security/ownership-violations.test.mjs
@@ -43,8 +43,8 @@ describe('Ownership Violation Attempts Integration Tests', () => {
 
     userA = await prisma.user.create({
       data: {
-        email: `userA-${Date.now()}@example.com`,
-        username: `userA-${Date.now()}`,
+        email: `userA-${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
+        username: `userA-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         password: 'hashedPassword123',
         firstName: 'User',
         lastName: 'A',
@@ -54,8 +54,8 @@ describe('Ownership Violation Attempts Integration Tests', () => {
 
     userB = await prisma.user.create({
       data: {
-        email: `userB-${Date.now()}@example.com`,
-        username: `userB-${Date.now()}`,
+        email: `userB-${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
+        username: `userB-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         password: 'hashedPassword123',
         firstName: 'User',
         lastName: 'B',
@@ -72,7 +72,7 @@ describe('Ownership Violation Attempts Integration Tests', () => {
 
     horseA = await prisma.horse.create({
       data: {
-        name: `HorseA-${Date.now()}`,
+        name: `HorseA-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         userId: userA.id, // Matches schema field (line 144)
         sex: 'mare',
         dateOfBirth: new Date(),
@@ -81,7 +81,7 @@ describe('Ownership Violation Attempts Integration Tests', () => {
 
     horseB = await prisma.horse.create({
       data: {
-        name: `HorseB-${Date.now()}`,
+        name: `HorseB-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         userId: userB.id, // Matches schema field (line 144)
         sex: 'stallion',
         dateOfBirth: new Date(),
@@ -90,7 +90,7 @@ describe('Ownership Violation Attempts Integration Tests', () => {
 
     groomA = await prisma.groom.create({
       data: {
-        name: `GroomA-${Date.now()}`,
+        name: `GroomA-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         userId: userA.id,
         speciality: 'TRAINING',
         personality: 'diligent',
@@ -99,7 +99,7 @@ describe('Ownership Violation Attempts Integration Tests', () => {
 
     groomB = await prisma.groom.create({
       data: {
-        name: `GroomB-${Date.now()}`,
+        name: `GroomB-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         userId: userB.id,
         speciality: 'CARE',
         personality: 'calm',

--- a/backend/__tests__/integration/security/parameter-pollution.test.mjs
+++ b/backend/__tests__/integration/security/parameter-pollution.test.mjs
@@ -39,8 +39,8 @@ describe('Parameter Pollution Attack Integration Tests', () => {
     // Create test user in database
     testUser = await prisma.user.create({
       data: {
-        email: `test-${Date.now()}@example.com`,
-        username: `testuser-${Date.now()}`,
+        email: `test-${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
+        username: `testuser-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         password: 'hashedPassword123',
         firstName: 'Test',
         lastName: 'User',
@@ -55,7 +55,7 @@ describe('Parameter Pollution Attack Integration Tests', () => {
     // Create test horse owned by user
     testHorse = await prisma.horse.create({
       data: {
-        name: `TestHorse-${Date.now()}`,
+        name: `TestHorse-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         sex: 'mare',
         dateOfBirth: new Date('2015-01-01'),
         userId: testUser.id, // Matches schema field (line 144)

--- a/backend/__tests__/integration/security/rate-limit-enforcement.test.mjs
+++ b/backend/__tests__/integration/security/rate-limit-enforcement.test.mjs
@@ -31,8 +31,8 @@ describe('Rate Limit Enforcement Integration Tests', () => {
     // Create a real test user in the database
     testUser = await prisma.user.create({
       data: {
-        email: `ratelimit-sec-${Date.now()}@example.com`,
-        username: `ratelimit-sec-${Date.now()}`,
+        email: `ratelimit-sec-${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
+        username: `ratelimit-sec-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         password: 'hashedPassword123',
         firstName: 'RateLimit',
         lastName: 'Test',

--- a/backend/__tests__/integration/security/sql-injection-attempts.test.mjs
+++ b/backend/__tests__/integration/security/sql-injection-attempts.test.mjs
@@ -61,7 +61,7 @@ describe('SQL Injection Attempts Integration Tests', () => {
   });
 
   beforeEach(async () => {
-    const uid = `${RUN_PREFIX}-${Date.now()}-${++_seq}`;
+    const uid = `${RUN_PREFIX}-${Date.now()}_${Math.random().toString(36).slice(2, 6)}-${++_seq}`;
     // Pre-clean: remove only users from THIS worker's prior iterations.
     // The previous filter (username startsWith 'testuser-') also matched
     // users other suites owned, which could leave an inconsistent FK

--- a/backend/__tests__/integration/session-lifecycle.test.mjs
+++ b/backend/__tests__/integration/session-lifecycle.test.mjs
@@ -527,12 +527,14 @@ describe('Session Lifecycle Management', () => {
       // Create an expired token directly in DB. We store a synthetic hash
       // here because this row is never consumed via createTokenPair; it
       // only needs to exist for the cleanup cron to purge (Equoria-uy73).
-      const expiredTokenHash = hashRefreshToken(`expired-test-token-${Date.now()}`);
+      const expiredTokenHash = hashRefreshToken(
+        `expired-test-token-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+      );
       await prisma.refreshToken.create({
         data: {
           tokenHash: expiredTokenHash,
           userId: testUser.id,
-          familyId: `expired-family-${Date.now()}`,
+          familyId: `expired-family-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           expiresAt: new Date(Date.now() - 24 * 60 * 60 * 1000), // 1 day ago
           isActive: true,
           isInvalidated: false,
@@ -564,9 +566,9 @@ describe('Session Lifecycle Management', () => {
       // Create an old invalidated token (hashed at rest — Equoria-uy73)
       const _oldInvalidatedToken = await prisma.refreshToken.create({
         data: {
-          tokenHash: hashRefreshToken(`old-invalidated-${Date.now()}`),
+          tokenHash: hashRefreshToken(`old-invalidated-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`),
           userId: testUser.id,
-          familyId: `old-family-${Date.now()}`,
+          familyId: `old-family-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // Expires in 7 days
           isActive: false,
           isInvalidated: true,
@@ -622,8 +624,8 @@ describe('Session Lifecycle Management', () => {
     it('should handle complete user journey: register -> login -> use session -> change password -> re-login', async () => {
       // Step 1: Register new user
       const newUserData = {
-        username: `lifecycle-${Date.now()}`,
-        email: `lifecycle-${Date.now()}@example.com`,
+        username: `lifecycle-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `lifecycle-${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
         password: 'TestPassword123!',
         firstName: 'Lifecycle',
         lastName: 'Test',

--- a/backend/__tests__/integration/token-rotation.test.mjs
+++ b/backend/__tests__/integration/token-rotation.test.mjs
@@ -479,7 +479,7 @@ describe('Token Rotation and Reuse Detection System', () => {
         {
           userId: testUser.id,
           type: 'refresh',
-          familyId: `test-family-${Date.now()}`,
+          familyId: `test-family-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         },
         process.env.JWT_REFRESH_SECRET,
         { expiresIn: '1ms' }, // Immediately expires
@@ -490,7 +490,7 @@ describe('Token Rotation and Reuse Detection System', () => {
         data: {
           tokenHash: hashRefreshToken(shortLivedToken),
           userId: testUser.id,
-          familyId: `test-family-${Date.now()}`,
+          familyId: `test-family-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           expiresAt: new Date(Date.now() + 1), // 1ms from now
           isActive: true,
           isInvalidated: false,
@@ -569,7 +569,7 @@ describe('Token Rotation and Reuse Detection System', () => {
   describe('Database Constraints and Security', () => {
     it('should_enforce_unique_constraints_on_token_families', async () => {
       // This test verifies database schema constraints
-      const familyId = `test-family-${Date.now()}`;
+      const familyId = `test-family-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
 
       // Attempt to create two active tokens with same family ID
       // This should be prevented by database constraints

--- a/backend/__tests__/performance/apiResponseOptimization.test.mjs
+++ b/backend/__tests__/performance/apiResponseOptimization.test.mjs
@@ -39,7 +39,7 @@ describe('API Response Optimization System', () => {
   let testUserId;
   const testHorseIds = [];
   let testApp;
-  const testRunId = `apiopt_${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+  const testRunId = `apiopt_${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.floor(Math.random() * 100000)}`;
   const testBreedName = `Optimization Test Breed ${testRunId}`;
 
   beforeAll(async () => {

--- a/backend/__tests__/performance/databaseOptimization.test.mjs
+++ b/backend/__tests__/performance/databaseOptimization.test.mjs
@@ -28,7 +28,7 @@ describe('Database Query Optimization', () => {
   let testUserId;
   const testHorseIds = [];
   let testBreed;
-  const testRunId = `perf_${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+  const testRunId = `perf_${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.floor(Math.random() * 100000)}`;
 
   beforeAll(async () => {
     // Create test data for performance testing

--- a/backend/__tests__/routes/apiOptimizationRoutes.test.mjs
+++ b/backend/__tests__/routes/apiOptimizationRoutes.test.mjs
@@ -28,7 +28,7 @@ describe('API Optimization Routes', () => {
   let testApp;
   let testUser;
   let authToken;
-  const testRunId = `apiopt_${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+  const testRunId = `apiopt_${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.floor(Math.random() * 100000)}`;
 
   beforeAll(async () => {
     // Create test user

--- a/backend/__tests__/services/cronJobService.test.mjs
+++ b/backend/__tests__/services/cronJobService.test.mjs
@@ -206,7 +206,9 @@ describe('Cron Job Service', () => {
     });
 
     it('should remove expired tokens for all users', async () => {
-      const user2 = await createTestUser({ email: `user2_${Date.now()}@example.com` });
+      const user2 = await createTestUser({
+        email: `user2_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
+      });
 
       // Create expired tokens for both users
       await createTestRefreshToken(user.id, {

--- a/backend/__tests__/unit/cacheHelper.test.mjs
+++ b/backend/__tests__/unit/cacheHelper.test.mjs
@@ -33,7 +33,7 @@ describe('Cache Helper', () => {
 
   describe('getCachedQuery() - In-Memory Fallback', () => {
     it('should execute and cache the query result', async () => {
-      const cacheKey = `test:key:${Date.now()}`;
+      const cacheKey = `test:key:${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
       const queryData = { id: 1, name: 'Test' };
       const queryFn = jest.fn(async () => queryData);
 
@@ -51,7 +51,7 @@ describe('Cache Helper', () => {
     });
 
     it('should respect TTL', async () => {
-      const cacheKey = `test:ttl:${Date.now()}`;
+      const cacheKey = `test:ttl:${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
       const queryFn = jest.fn(async () => ({ data: 'old' }));
 
       // Cache with 0s TTL (expires immediately)
@@ -64,7 +64,7 @@ describe('Cache Helper', () => {
     });
 
     it('should handle undefined/null results', async () => {
-      const cacheKey = `test:null:${Date.now()}`;
+      const cacheKey = `test:null:${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
       const queryFn = jest.fn(async () => null);
 
       const result = await getCachedQuery(cacheKey, queryFn);
@@ -75,7 +75,7 @@ describe('Cache Helper', () => {
 
   describe('invalidateCache()', () => {
     it('should remove items from cache', async () => {
-      const cacheKey = `test:invalidate:${Date.now()}`;
+      const cacheKey = `test:invalidate:${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
       const queryFn = jest.fn(async () => 'fresh');
 
       // Cache it

--- a/backend/__tests__/unit/email-verification.test.mjs
+++ b/backend/__tests__/unit/email-verification.test.mjs
@@ -144,7 +144,9 @@ describe('Email Verification Service - Unit Tests', () => {
           data: {
             // Hashed at rest — Equoria-uy73. This row is just padding to hit
             // the MAX_PENDING_TOKENS ceiling; the raw token is not read back.
-            tokenHash: hashVerificationToken(`old-token-${i}-${Date.now()}-${Math.random()}`),
+            tokenHash: hashVerificationToken(
+              `old-token-${i}-${Date.now()}_${Math.random().toString(36).slice(2, 6)}-${Math.random()}`,
+            ),
             userId: testUser.id,
             email: testUser.email,
             expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),

--- a/backend/tests/auth.test.mjs
+++ b/backend/tests/auth.test.mjs
@@ -191,7 +191,7 @@ describe('🔐 INTEGRATION: Authentication System - User Registration & Session 
 
       // Second registration with same email
       const response = await authPost('/api/auth/register')
-        .send({ ...userData, username: `other_${Date.now()}` }) // Use a different username
+        .send({ ...userData, username: `other_${Date.now()}_${Math.random().toString(36).slice(2, 6)}` }) // Use a different username
         .expect(400);
 
       expect(response.body.success).toBe(false);
@@ -237,7 +237,7 @@ describe('🔐 INTEGRATION: Authentication System - User Registration & Session 
 
     it('should reject login with invalid email', async () => {
       const loginData = {
-        email: `nonexistent_${Date.now()}@example.com`,
+        email: `nonexistent_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
         password: 'Password123!',
       };
 

--- a/backend/tests/breedingPrediction.test.mjs
+++ b/backend/tests/breedingPrediction.test.mjs
@@ -41,7 +41,7 @@ describe('Breeding Prediction System', () => {
     // Create test breed
     testBreed = await prisma.breed.create({
       data: {
-        name: `TestBreed_${Date.now()}`,
+        name: `TestBreed_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         description: 'Test breed for breeding prediction tests',
       },
     });
@@ -49,10 +49,10 @@ describe('Breeding Prediction System', () => {
     // Create test user
     testUser = await prisma.user.create({
       data: {
-        username: `testuser_${Date.now()}`,
+        username: `testuser_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         firstName: 'Test',
         lastName: 'User',
-        email: `test_${Date.now()}@example.com`,
+        email: `test_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
         password: 'hashedpassword',
         money: 10000,
         xp: 100,
@@ -63,7 +63,7 @@ describe('Breeding Prediction System', () => {
     // Create test groom
     testGroom = await prisma.groom.create({
       data: {
-        name: `TestGroom_${Date.now()}`,
+        name: `TestGroom_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         speciality: 'foal_care',
         experience: 10,
         skillLevel: 'expert',
@@ -77,7 +77,7 @@ describe('Breeding Prediction System', () => {
     // Create test stallion (5 years old)
     testStallion = await prisma.horse.create({
       data: {
-        name: `TestStallion_${Date.now()}`,
+        name: `TestStallion_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         sex: 'stallion',
         dateOfBirth: new Date(Date.now() - 5 * 365 * 24 * 60 * 60 * 1000), // 5 years old
         temperament: 'spirited',
@@ -90,7 +90,7 @@ describe('Breeding Prediction System', () => {
     // Create test mare (4 years old)
     testMare = await prisma.horse.create({
       data: {
-        name: `TestMare_${Date.now()}`,
+        name: `TestMare_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         sex: 'mare',
         dateOfBirth: new Date(Date.now() - 4 * 365 * 24 * 60 * 60 * 1000), // 4 years old
         temperament: 'calm',

--- a/backend/tests/competitionController-business-logic.test.mjs
+++ b/backend/tests/competitionController-business-logic.test.mjs
@@ -154,7 +154,7 @@ describe('🏆 INTEGRATION: Competition Controller Business Logic - Real Competi
     }
 
     // Create test show with unique name or find existing one
-    const showName = `Business Logic Test Show ${Date.now()}`;
+    const showName = `Business Logic Test Show ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
     testShow = await prisma.show.create({
       data: {
         name: showName,

--- a/backend/tests/controllers/dynamicCompatibilityController.test.mjs
+++ b/backend/tests/controllers/dynamicCompatibilityController.test.mjs
@@ -63,7 +63,7 @@ describe('Dynamic Compatibility Controller API', () => {
       testBreedId = breed.id;
     }
 
-    const uid = `${RUN_PREFIX}-${Date.now()}`;
+    const uid = `${RUN_PREFIX}-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
     const groomData = [
       {
         name: `Calm Expert ${uid}`,

--- a/backend/tests/controllers/personalityEvolutionController.test.mjs
+++ b/backend/tests/controllers/personalityEvolutionController.test.mjs
@@ -50,8 +50,8 @@ describe('Personality Evolution Controller API', () => {
     // Create test user
     testUser = await prisma.user.create({
       data: {
-        username: `personality_evolution_api_${Date.now()}`,
-        email: `personality_evolution_api_${Date.now()}@test.com`,
+        username: `personality_evolution_api_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `personality_evolution_api_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
         password: 'test_hash',
         firstName: 'Test',
         lastName: 'User',

--- a/backend/tests/cronJobsIntegration.test.mjs
+++ b/backend/tests/cronJobsIntegration.test.mjs
@@ -37,7 +37,7 @@ describe('INTEGRATION: Admin Cron API Routes — Real Database', () => {
   let adminUser;
   let adminToken;
   let testFoal;
-  const ts = `${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+  const ts = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).slice(2, 7)}`;
 
   beforeAll(async () => {
     // Create a real admin user in the database

--- a/backend/tests/foalCreationIntegration.test.mjs
+++ b/backend/tests/foalCreationIntegration.test.mjs
@@ -37,7 +37,7 @@ describe('INTEGRATION: Foal Creation API — Real Database', () => {
   let testDam;
   let authToken;
   const createdFoalIds = [];
-  const ts = `${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+  const ts = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).slice(2, 7)}`;
 
   beforeAll(async () => {
     // Create a real user in the database

--- a/backend/tests/foalEnrichmentIntegration.test.mjs
+++ b/backend/tests/foalEnrichmentIntegration.test.mjs
@@ -35,7 +35,7 @@ describe('INTEGRATION: Foal Enrichment API — Real Database', () => {
   let testUser;
   let testFoal;
   let authToken;
-  const ts = `${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+  const ts = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).slice(2, 7)}`;
 
   beforeAll(async () => {
     // Create a real user in the database

--- a/backend/tests/foalTaskLogStorage.test.mjs
+++ b/backend/tests/foalTaskLogStorage.test.mjs
@@ -60,7 +60,7 @@ describe('Foal Task Log Storage', () => {
     }
 
     // Create test user
-    const uniqueSuffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+    const uniqueSuffix = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.floor(Math.random() * 100000)}`;
     testUser = await prisma.user.create({
       data: {
         id: `test-user-task-log-${uniqueSuffix}`,

--- a/backend/tests/foalTaskLogStreakData.test.mjs
+++ b/backend/tests/foalTaskLogStreakData.test.mjs
@@ -65,7 +65,7 @@ describe('Foal Task Log and Streak Data', () => {
     }
 
     // Create test user
-    const uniqueSuffix = `${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+    const uniqueSuffix = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.floor(Math.random() * 100000)}`;
     testUser = await prisma.user.create({
       data: {
         id: `test-user-task-log-streak-${uniqueSuffix}`,

--- a/backend/tests/groomBondingIntegration.test.mjs
+++ b/backend/tests/groomBondingIntegration.test.mjs
@@ -83,7 +83,7 @@ describe('Groom Bonding System Integration', () => {
     await cleanupTestData();
 
     // Create test user with unique identifiers
-    const suffix = `${Date.now()}_${Math.random().toString(36).substr(2, 5)}`;
+    const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).substr(2, 5)}`;
     testUser = await prisma.user.create({
       data: {
         id: `user-bonding-${suffix}`,

--- a/backend/tests/groomBonusTraits.test.mjs
+++ b/backend/tests/groomBonusTraits.test.mjs
@@ -39,7 +39,8 @@ describe('Groom Bonus Traits System', () => {
     // a prior run aborted leaving stale `TestBreed_<ts>` rows AND
     // protects against parallel-shard races re-using the same Date.now().
     // Date.now() alone has hit the breed.name unique constraint in CI.
-    const uid = () => `${Date.now()}_${Math.random().toString(36).substring(2, 10)}`;
+    const uid = () =>
+      `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).substring(2, 10)}`;
 
     // Create test breed first
     testBreed = await prisma.breed.create({

--- a/backend/tests/groomPersonalityTraitBonus.test.mjs
+++ b/backend/tests/groomPersonalityTraitBonus.test.mjs
@@ -44,7 +44,7 @@ describe('Groom Personality Trait Bonus System - REAL SYSTEM TESTS', () => {
     // Create test breed first
     testBreed = await prisma.breed.create({
       data: {
-        name: `TestBreed_${Date.now()}`,
+        name: `TestBreed_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         description: 'Test breed for personality tests',
       },
     });
@@ -52,10 +52,10 @@ describe('Groom Personality Trait Bonus System - REAL SYSTEM TESTS', () => {
     // Create test user with real database operations
     testUser = await prisma.user.create({
       data: {
-        username: `testuser_${Date.now()}`,
+        username: `testuser_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         firstName: 'Test',
         lastName: 'User',
-        email: `test_${Date.now()}@example.com`,
+        email: `test_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
         password: 'hashedpassword',
         money: 10000,
         xp: 100,
@@ -66,7 +66,7 @@ describe('Groom Personality Trait Bonus System - REAL SYSTEM TESTS', () => {
     // Create test horse with temperament
     testHorse = await prisma.horse.create({
       data: {
-        name: `TestHorse_${Date.now()}`,
+        name: `TestHorse_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         userId: testUser.id,
         dateOfBirth: new Date(Date.now() - 0 * 24 * 60 * 60 * 1000), // 0 days old (newborn for imprinting)
         temperament: FOAL_TEMPERAMENT_TYPES.SPIRITED,
@@ -81,7 +81,7 @@ describe('Groom Personality Trait Bonus System - REAL SYSTEM TESTS', () => {
     // Create test groom with personality
     testGroom = await prisma.groom.create({
       data: {
-        name: `TestGroom_${Date.now()}`,
+        name: `TestGroom_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         speciality: 'foalCare',
         experience: 5,
         skillLevel: 'intermediate',

--- a/backend/tests/horseAgingIntegration.test.mjs
+++ b/backend/tests/horseAgingIntegration.test.mjs
@@ -96,12 +96,12 @@ describe('Horse Aging Integration', () => {
     await cleanupTestData();
 
     // Create test user
-    const userId = `aging-int-user-${Date.now()}-${Math.random().toString(36).substr(2, 5)}`;
+    const userId = `aging-int-user-${Date.now()}_${Math.random().toString(36).slice(2, 6)}-${Math.random().toString(36).substr(2, 5)}`;
     testUser = await prisma.user.create({
       data: {
         id: userId,
-        username: `agingintuser_${Date.now()}_${Math.random().toString(36).substr(2, 5)}`,
-        email: `agingint_${Date.now()}_${Math.random().toString(36).substr(2, 5)}@example.com`,
+        username: `agingintuser_${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).substr(2, 5)}`,
+        email: `agingint_${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).substr(2, 5)}@example.com`,
         password: 'TestPassword123!',
         firstName: 'Aging',
         lastName: 'Integration',
@@ -113,7 +113,7 @@ describe('Horse Aging Integration', () => {
     // Create test breed
     testBreed = await prisma.breed.create({
       data: {
-        name: `Int Test Breed ${Date.now()}_${Math.random().toString(36).substr(2, 5)}`,
+        name: `Int Test Breed ${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).substr(2, 5)}`,
         description: 'Test breed for aging integration',
       },
     });

--- a/backend/tests/horseAgingSystem.test.mjs
+++ b/backend/tests/horseAgingSystem.test.mjs
@@ -64,9 +64,9 @@ describe('Horse Aging System', () => {
     // Create test user
     testUser = await prisma.user.create({
       data: {
-        id: `aging-user-${Date.now()}-${Math.random()}`,
-        username: `aginguser-${Date.now()}`,
-        email: `aging-${Date.now()}@example.com`,
+        id: `aging-user-${Date.now()}_${Math.random().toString(36).slice(2, 6)}-${Math.random()}`,
+        username: `aginguser-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `aging-${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
         password: 'TestPassword123!',
         firstName: 'Aging',
         lastName: 'Tester',
@@ -78,7 +78,7 @@ describe('Horse Aging System', () => {
     // Create test breed
     testBreed = await prisma.breed.create({
       data: {
-        name: `Test Breed ${Date.now()}`,
+        name: `Test Breed ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         description: 'Test breed for aging',
       },
     });

--- a/backend/tests/horseModelAtBirth.test.mjs
+++ b/backend/tests/horseModelAtBirth.test.mjs
@@ -26,7 +26,7 @@ jest.unstable_mockModule('../utils/logger.mjs', () => ({
 
 const { createHorse } = await import('../models/horseModel.mjs');
 
-const UNIQUE = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+const UNIQUE = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).slice(2, 8)}`;
 
 let breed;
 let sire;

--- a/backend/tests/integration/advancedBreedingGeneticsAPI.test.mjs
+++ b/backend/tests/integration/advancedBreedingGeneticsAPI.test.mjs
@@ -49,7 +49,7 @@ describe('🧬 Advanced Breeding Genetics API Integration', () => {
     // of "parallel isolation" flakes.
     const workerId = process.env.JEST_WORKER_ID || String(process.pid);
     const random = Math.random().toString(36).slice(2, 8);
-    testSuffix = `${Date.now()}_${workerId}_${random}`;
+    testSuffix = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${workerId}_${random}`;
     usernameSuffix = testSuffix.replace(/[^a-zA-Z0-9]/g, '').slice(-16);
 
     // Create test user using helper function for more reliable authentication

--- a/backend/tests/integration/clubAPI.test.mjs
+++ b/backend/tests/integration/clubAPI.test.mjs
@@ -55,7 +55,7 @@ describe('🏇 INTEGRATION: Club API', () => {
         .set('Cookie', __csrf__.cookieHeader)
         .set('X-CSRF-Token', __csrf__.csrfToken)
         .send({
-          name: `Test Club ${Date.now()}`,
+          name: `Test Club ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           type: 'discipline',
           category: 'Dressage',
           description: 'For dressage lovers',
@@ -72,7 +72,7 @@ describe('🏇 INTEGRATION: Club API', () => {
     });
 
     it('should reject duplicate club name', async () => {
-      const clubName = `Dup Club ${Date.now()}`;
+      const clubName = `Dup Club ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
       await request(app)
         .post('/api/clubs')
         .set('Authorization', `Bearer ${leaderToken}`)

--- a/backend/tests/integration/competitionAPIEndpoints.integration.test.mjs
+++ b/backend/tests/integration/competitionAPIEndpoints.integration.test.mjs
@@ -28,8 +28,8 @@ describe('🚀 INTEGRATION: Competition API Endpoints', () => {
   beforeAll(async () => {
     // Create test user
     const userResult = await createTestUser({
-      username: `competitionapi_${Date.now()}`,
-      email: `competitionapi_${Date.now()}@example.com`,
+      username: `competitionapi_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+      email: `competitionapi_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
       money: 10000,
       xp: 500,
       level: 5,
@@ -152,8 +152,8 @@ describe('🚀 INTEGRATION: Competition API Endpoints', () => {
     test('should reject access to horse not owned by user', async () => {
       // Create another user and horse
       const otherUserResult = await createTestUser({
-        username: `otheruser_${Date.now()}`,
-        email: `other_${Date.now()}@example.com`,
+        username: `otheruser_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `other_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
       });
       const otherHorse = await createTestHorse({
         userId: otherUserResult.user.id,
@@ -296,8 +296,8 @@ describe('🚀 INTEGRATION: Competition API Endpoints', () => {
     test('should reject execution by non-host user', async () => {
       // Create another user
       const otherUserResult = await createTestUser({
-        username: `nonhost_${Date.now()}`,
-        email: `nonhost_${Date.now()}@example.com`,
+        username: `nonhost_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `nonhost_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
       });
 
       const response = await request(app)

--- a/backend/tests/integration/epigeneticFlagRoutes.test.mjs
+++ b/backend/tests/integration/epigeneticFlagRoutes.test.mjs
@@ -28,9 +28,9 @@ describe('Epigenetic Flag Routes Integration Tests', () => {
     // Create test user
     testUser = await prisma.user.create({
       data: {
-        id: `test-user-epigenetic-${Date.now()}`,
-        username: `testuser${Date.now()}`,
-        email: `test${Date.now()}@example.com`,
+        id: `test-user-epigenetic-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        username: `testuser${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `test${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
         password: 'TestPassword123!',
         role: 'admin',
         firstName: 'Test',

--- a/backend/tests/integration/epigeneticTraitSystem.test.mjs
+++ b/backend/tests/integration/epigeneticTraitSystem.test.mjs
@@ -317,8 +317,8 @@ describe('Epigenetic Trait System Integration Tests', () => {
       // Create another user
       const otherUser = await prisma.user.create({
         data: {
-          username: `otherUser_${Date.now()}`,
-          email: `other_${Date.now()}@test.com`,
+          username: `otherUser_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+          email: `other_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
           password: 'hashedPassword',
           firstName: 'Other',
           lastName: 'User',
@@ -441,8 +441,8 @@ describe('Trait History Service', () => {
     // Create minimal test data for service tests
     testUser = await prisma.user.create({
       data: {
-        username: `serviceTestUser_${Date.now()}`,
-        email: `service_${Date.now()}@test.com`,
+        username: `serviceTestUser_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `service_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
         password: 'hashedPassword',
         firstName: 'Service',
         lastName: 'Test',

--- a/backend/tests/integration/groomSalarySystem.test.mjs
+++ b/backend/tests/integration/groomSalarySystem.test.mjs
@@ -27,7 +27,7 @@ describe('Groom Salary System', () => {
   let authToken;
 
   beforeEach(async () => {
-    const testSuffix = `${Date.now()}_${Math.random().toString(16).slice(2, 8)}`;
+    const testSuffix = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(16).slice(2, 8)}`;
 
     testUser = await prisma.user.create({
       data: {
@@ -199,7 +199,7 @@ describe('Groom Salary System', () => {
 
     it('should validate groom ownership', async () => {
       // Create another user's groom
-      const uniqueSuffix = `${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+      const uniqueSuffix = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.floor(Math.random() * 10000)}`;
       const otherUser = await prisma.user.create({
         data: {
           username: `otherSalaryUser_${uniqueSuffix}`,

--- a/backend/tests/integration/groomWorkflowIntegration.test.mjs
+++ b/backend/tests/integration/groomWorkflowIntegration.test.mjs
@@ -126,7 +126,7 @@ describe('Groom Workflow Integration Tests', () => {
     });
 
     // Create unique suffix
-    const suffix = `${Date.now()}_${Math.random().toString(36).substr(2, 5)}`;
+    const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).substr(2, 5)}`;
 
     // Create test breed
     testBreed = await prisma.breed.create({
@@ -470,9 +470,9 @@ describe('Groom Workflow Integration Tests', () => {
       // Create different user
       const otherUser = await prisma.user.create({
         data: {
-          id: `other-user-groom-${Date.now()}`,
-          username: `otheruser_${Date.now()}`,
-          email: `other_${Date.now()}@example.com`,
+          id: `other-user-groom-${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+          username: `otheruser_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+          email: `other_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
           password: 'password',
           firstName: 'Other',
           lastName: 'User',

--- a/backend/tests/integration/horseOverview.test.mjs
+++ b/backend/tests/integration/horseOverview.test.mjs
@@ -157,7 +157,7 @@ describe('🏇 INTEGRATION: Horse Overview API - Real Database Integration', () 
       // Create test show for competition result
       const testShow = await prisma.show.create({
         data: {
-          name: `Summer Invitational ${Date.now()}`,
+          name: `Summer Invitational ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           discipline: 'Dressage',
           levelMin: 1,
           levelMax: 10,

--- a/backend/tests/integration/horseRoutes.test.mjs
+++ b/backend/tests/integration/horseRoutes.test.mjs
@@ -26,7 +26,7 @@ describe('Horse Routes Integration Tests', () => {
   let foalHorse;
 
   beforeEach(async () => {
-    const ts = `${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+    const ts = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).slice(2, 7)}`;
     testUser = await prisma.user.create({
       data: {
         username: `testuser_hr_${ts}`,
@@ -118,7 +118,7 @@ describe('Horse Routes Integration Tests', () => {
     });
 
     test('should return 403 when accessing another users trainable horses', async () => {
-      const otherTs = `${Date.now()}_other`;
+      const otherTs = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_other`;
       const otherUser = await prisma.user.create({
         data: {
           username: `other_hr_${otherTs}`,

--- a/backend/tests/integration/marketplaceAPI.test.mjs
+++ b/backend/tests/integration/marketplaceAPI.test.mjs
@@ -272,8 +272,8 @@ describe('🛒 INTEGRATION: Marketplace API', () => {
     it('should reject purchase with insufficient funds', async () => {
       // Create a broke buyer
       const brokeUser = await createTestUser({
-        username: `broke_${Date.now()}`,
-        email: `broke_${Date.now()}@test.com`,
+        username: `broke_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `broke_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
         money: 100,
       });
 
@@ -381,8 +381,8 @@ describe('🛒 INTEGRATION: Marketplace API', () => {
 
     it('should return empty history for new user', async () => {
       const newUser = await createTestUser({
-        username: `hist_${Date.now()}`,
-        email: `hist_${Date.now()}@test.com`,
+        username: `hist_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `hist_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
       });
 
       const res = await request(app)
@@ -409,7 +409,7 @@ describe('🛒 INTEGRATION: Marketplace API', () => {
       const breed = await prisma.breed.findFirst();
       delistHorse = await prisma.horse.create({
         data: {
-          name: `DelistHorse_${Date.now()}`,
+          name: `DelistHorse_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'stallion',
           age: 4,
           dateOfBirth: new Date('2020-01-01'),

--- a/backend/tests/integration/messageAPI.test.mjs
+++ b/backend/tests/integration/messageAPI.test.mjs
@@ -145,8 +145,8 @@ describe('📬 INTEGRATION: Messages API', () => {
 
     it('should block access to messages not yours', async () => {
       const other = await createTestUser({
-        username: `other_${Date.now()}`,
-        email: `other_${Date.now()}@test.com`,
+        username: `other_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `other_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
       });
       const res = await request(app)
         .get(`/api/messages/${sentMessageId}`)

--- a/backend/tests/integration/traitRoutes.test.mjs
+++ b/backend/tests/integration/traitRoutes.test.mjs
@@ -47,7 +47,7 @@ describe('Trait Routes Integration Tests', () => {
       // Create real test breed in database
       testBreed = await prisma.breed.create({
         data: {
-          name: `Test Breed for Traits ${Date.now()}`,
+          name: `Test Breed for Traits ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           description: 'Test breed for trait discovery testing',
         },
       });
@@ -57,7 +57,7 @@ describe('Trait Routes Integration Tests', () => {
       const twoYearsAgo = new Date(Date.now() - 2 * 365 * 24 * 60 * 60 * 1000);
       testHorse = await prisma.horse.create({
         data: {
-          name: `Test Discovery Horse ${Date.now()}`,
+          name: `Test Discovery Horse ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'mare',
           dateOfBirth: twoYearsAgo,
           breed: { connect: { id: testBreed.id } },

--- a/backend/tests/integration/user.test.mjs
+++ b/backend/tests/integration/user.test.mjs
@@ -11,7 +11,7 @@ import prisma from '../../../packages/database/prismaClient.mjs';
 import bcrypt from 'bcryptjs';
 import { getUserById, getUserWithHorses, getUserByEmail } from '../../models/userModel.mjs';
 
-const UNIQUE = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+const UNIQUE = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).slice(2, 8)}`;
 
 let testUser;
 const testHorseIds = [];

--- a/backend/tests/integration/xpLogging.test.mjs
+++ b/backend/tests/integration/xpLogging.test.mjs
@@ -13,7 +13,7 @@ import prisma from '../../../packages/database/prismaClient.mjs';
 import bcrypt from 'bcryptjs';
 import { trainHorse } from '../../controllers/trainingController.mjs';
 
-const UNIQUE = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+const UNIQUE = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).slice(2, 8)}`;
 
 let testUser;
 let testHorse;

--- a/backend/tests/legacyScoreTraitIntegration.test.mjs
+++ b/backend/tests/legacyScoreTraitIntegration.test.mjs
@@ -38,7 +38,7 @@ describe('Legacy Score Trait Integration System', () => {
     // Create test breed
     testBreed = await prisma.breed.create({
       data: {
-        name: `TestBreed_${Date.now()}`,
+        name: `TestBreed_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         description: 'Test breed for legacy score tests',
       },
     });
@@ -46,10 +46,10 @@ describe('Legacy Score Trait Integration System', () => {
     // Create test user
     testUser = await prisma.user.create({
       data: {
-        username: `testuser_${Date.now()}`,
+        username: `testuser_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         firstName: 'Test',
         lastName: 'User',
-        email: `test_${Date.now()}@example.com`,
+        email: `test_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
         password: 'hashedpassword',
         money: 10000,
         xp: 100,
@@ -60,7 +60,7 @@ describe('Legacy Score Trait Integration System', () => {
     // Create test groom
     testGroom = await prisma.groom.create({
       data: {
-        name: `TestGroom_${Date.now()}`,
+        name: `TestGroom_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         speciality: 'foal_care',
         experience: 10,
         skillLevel: 'expert',
@@ -74,7 +74,7 @@ describe('Legacy Score Trait Integration System', () => {
     // Create test horse (4 years old to test legacy score calculation)
     testHorse = await prisma.horse.create({
       data: {
-        name: `TestHorse_${Date.now()}`,
+        name: `TestHorse_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         sex: 'stallion',
         dateOfBirth: new Date(Date.now() - 4 * 365 * 24 * 60 * 60 * 1000), // 4 years old
         temperament: 'spirited',

--- a/backend/tests/routes/advancedEpigeneticRoutes.test.mjs
+++ b/backend/tests/routes/advancedEpigeneticRoutes.test.mjs
@@ -35,8 +35,8 @@ describe('Advanced Epigenetic API Routes', () => {
     // Create test user
     testUser = await prisma.user.create({
       data: {
-        username: `adv_epi_api_${Date.now()}`,
-        email: `adv_epi_api_${Date.now()}@test.com`,
+        username: `adv_epi_api_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `adv_epi_api_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
         password: 'test_hash',
         firstName: 'Test',
         lastName: 'User',
@@ -53,7 +53,7 @@ describe('Advanced Epigenetic API Routes', () => {
     testGrooms = await Promise.all([
       prisma.groom.create({
         data: {
-          name: `Test Groom Calm ${Date.now()}`,
+          name: `Test Groom Calm ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           personality: 'calm',
           epigeneticInfluenceType: 'calm',
           skillLevel: 'expert',
@@ -75,7 +75,7 @@ describe('Advanced Epigenetic API Routes', () => {
       // Young foal for developmental windows
       prisma.horse.create({
         data: {
-          name: `Test Foal API ${Date.now()}`,
+          name: `Test Foal API ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'filly',
           dateOfBirth: oneWeekAgo,
           userId: testUser.id,
@@ -87,7 +87,7 @@ describe('Advanced Epigenetic API Routes', () => {
       // Older foal with traits for interactions
       prisma.horse.create({
         data: {
-          name: `Test Horse API ${Date.now()}`,
+          name: `Test Horse API ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'colt',
           dateOfBirth: oneMonthAgo,
           userId: testUser.id,
@@ -214,8 +214,8 @@ describe('Advanced Epigenetic API Routes', () => {
       // Create another user's horse
       const otherUser = await prisma.user.create({
         data: {
-          username: `other_user_${Date.now()}`,
-          email: `other_user_${Date.now()}@test.com`,
+          username: `other_user_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+          email: `other_user_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
           password: 'test_hash',
           firstName: 'Other',
           lastName: 'User',
@@ -225,7 +225,7 @@ describe('Advanced Epigenetic API Routes', () => {
 
       const otherHorse = await prisma.horse.create({
         data: {
-          name: `Other Horse ${Date.now()}`,
+          name: `Other Horse ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'gelding',
           dateOfBirth: new Date(),
           userId: otherUser.id,

--- a/backend/tests/routes/enhancedReportingRoutes.test.mjs
+++ b/backend/tests/routes/enhancedReportingRoutes.test.mjs
@@ -35,8 +35,8 @@ describe('Enhanced Reporting API Routes', () => {
     // Create test user
     testUser = await prisma.user.create({
       data: {
-        username: `enh_report_${Date.now()}`,
-        email: `enh_report_${Date.now()}@test.com`,
+        username: `enh_report_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `enh_report_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
         password: 'test_hash',
         firstName: 'Test',
         lastName: 'User',
@@ -53,7 +53,7 @@ describe('Enhanced Reporting API Routes', () => {
     testGrooms = await Promise.all([
       prisma.groom.create({
         data: {
-          name: `Test Groom Report ${Date.now()}`,
+          name: `Test Groom Report ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           personality: 'calm',
           epigeneticInfluenceType: 'calm',
           skillLevel: 'expert',
@@ -76,7 +76,7 @@ describe('Enhanced Reporting API Routes', () => {
       // Young foal with developing traits
       prisma.horse.create({
         data: {
-          name: `Test Foal Report ${Date.now()}`,
+          name: `Test Foal Report ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'filly',
           dateOfBirth: oneWeekAgo,
           userId: testUser.id,
@@ -88,7 +88,7 @@ describe('Enhanced Reporting API Routes', () => {
       // Older foal with established traits
       prisma.horse.create({
         data: {
-          name: `Test Horse Report ${Date.now()}`,
+          name: `Test Horse Report ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'colt',
           dateOfBirth: oneMonthAgo,
           userId: testUser.id,
@@ -100,7 +100,7 @@ describe('Enhanced Reporting API Routes', () => {
       // Mature foal with complex traits
       prisma.horse.create({
         data: {
-          name: `Test Mature Report ${Date.now()}`,
+          name: `Test Mature Report ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'gelding',
           dateOfBirth: twoMonthsAgo,
           userId: testUser.id,
@@ -345,8 +345,8 @@ describe('Enhanced Reporting API Routes', () => {
       // Create another user's horse
       const otherUser = await prisma.user.create({
         data: {
-          username: `other_report_${Date.now()}`,
-          email: `other_report_${Date.now()}@test.com`,
+          username: `other_report_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+          email: `other_report_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
           password: 'test_hash',
           firstName: 'Other',
           lastName: 'User',
@@ -356,7 +356,7 @@ describe('Enhanced Reporting API Routes', () => {
 
       const otherHorse = await prisma.horse.create({
         data: {
-          name: `Other Horse Report ${Date.now()}`,
+          name: `Other Horse Report ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'gelding',
           dateOfBirth: new Date(),
           userId: otherUser.id,

--- a/backend/tests/routes/groomRetirementRoutes.test.mjs
+++ b/backend/tests/routes/groomRetirementRoutes.test.mjs
@@ -27,7 +27,7 @@ describe('Groom Retirement Routes', () => {
   beforeEach(async () => {
     // Create a fresh user for each test — avoids FK violations from test interference
     // when the full suite runs and Prisma connections are recycled between test files.
-    const ts = `${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
+    const ts = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).slice(2, 7)}`;
     testUser = await prisma.user.create({
       data: {
         username: `testuser_routes_${ts}`,

--- a/backend/tests/schema-validation.test.mjs
+++ b/backend/tests/schema-validation.test.mjs
@@ -43,7 +43,7 @@ describe('Schema Validation', () => {
 
   beforeEach(async () => {
     // Generate unique ID for this test
-    uniqueId = `schema-test-user-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    uniqueId = `schema-test-user-${Date.now()}_${Math.random().toString(36).slice(2, 6)}-${Math.random().toString(36).substr(2, 9)}`;
 
     // Create test breed
     testBreed = await prisma.breed.create({
@@ -57,8 +57,8 @@ describe('Schema Validation', () => {
     testUser = await prisma.user.create({
       data: {
         id: uniqueId,
-        username: `schematestuser${Date.now()}`,
-        email: `schema-test-${Date.now()}@example.com`,
+        username: `schematestuser${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `schema-test-${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
         password: 'TestPassword123!',
         firstName: 'Schema',
         lastName: 'Tester',

--- a/backend/tests/services/carePatternAnalyzerEnhanced.test.mjs
+++ b/backend/tests/services/carePatternAnalyzerEnhanced.test.mjs
@@ -31,8 +31,8 @@ describe('Enhanced Care Pattern Analyzer', () => {
     // Create test user
     testUser = await prisma.user.create({
       data: {
-        username: `carepattern_${Date.now()}`,
-        email: `carepattern_${Date.now()}@test.com`,
+        username: `carepattern_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `carepattern_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
         password: 'test_hash',
         firstName: 'Test',
         lastName: 'User',
@@ -46,7 +46,7 @@ describe('Enhanced Care Pattern Analyzer', () => {
     testGrooms = await Promise.all([
       prisma.groom.create({
         data: {
-          name: `Expert Calm Groom ${Date.now()}`,
+          name: `Expert Calm Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           personality: 'calm',
           epigeneticInfluenceType: 'calm',
           skillLevel: 'expert',
@@ -57,7 +57,7 @@ describe('Enhanced Care Pattern Analyzer', () => {
       }),
       prisma.groom.create({
         data: {
-          name: `Novice Energetic Groom ${Date.now()}`,
+          name: `Novice Energetic Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           personality: 'energetic',
           epigeneticInfluenceType: 'energetic',
           skillLevel: 'novice',
@@ -68,7 +68,7 @@ describe('Enhanced Care Pattern Analyzer', () => {
       }),
       prisma.groom.create({
         data: {
-          name: `Experienced Methodical Groom ${Date.now()}`,
+          name: `Experienced Methodical Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           personality: 'methodical',
           epigeneticInfluenceType: 'methodical',
           skillLevel: 'experienced',
@@ -88,7 +88,7 @@ describe('Enhanced Care Pattern Analyzer', () => {
       // Horse with consistent high-quality care
       prisma.horse.create({
         data: {
-          name: `Test Horse Consistent ${Date.now()}`,
+          name: `Test Horse Consistent ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'filly',
           dateOfBirth: oneMonthAgo,
           userId: testUser.id,
@@ -100,7 +100,7 @@ describe('Enhanced Care Pattern Analyzer', () => {
       // Horse with declining care quality
       prisma.horse.create({
         data: {
-          name: `Test Horse Declining ${Date.now()}`,
+          name: `Test Horse Declining ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'colt',
           dateOfBirth: twoWeeksAgo,
           userId: testUser.id,
@@ -112,7 +112,7 @@ describe('Enhanced Care Pattern Analyzer', () => {
       // Horse with improving care quality
       prisma.horse.create({
         data: {
-          name: `Test Horse Improving ${Date.now()}`,
+          name: `Test Horse Improving ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'gelding',
           dateOfBirth: oneMonthAgo,
           userId: testUser.id,

--- a/backend/tests/services/developmentalWindowSystem.test.mjs
+++ b/backend/tests/services/developmentalWindowSystem.test.mjs
@@ -36,8 +36,8 @@ describe('Developmental Window System', () => {
     // Create test user
     testUser = await prisma.user.create({
       data: {
-        username: `dev_window_${Date.now()}`,
-        email: `dev_window_${Date.now()}@test.com`,
+        username: `dev_window_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `dev_window_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
         password: 'test_hash',
         firstName: 'Test',
         lastName: 'User',
@@ -51,7 +51,7 @@ describe('Developmental Window System', () => {
     testGrooms = await Promise.all([
       prisma.groom.create({
         data: {
-          name: `Developmental Groom ${Date.now()}`,
+          name: `Developmental Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           personality: 'calm',
           epigeneticInfluenceType: 'calm',
           skillLevel: 'expert',
@@ -76,7 +76,7 @@ describe('Developmental Window System', () => {
       // Newborn foal - imprinting window
       prisma.horse.create({
         data: {
-          name: `Test Foal Newborn ${Date.now()}`,
+          name: `Test Foal Newborn ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'filly',
           dateOfBirth: oneDayAgo,
           userId: testUser.id,
@@ -88,7 +88,7 @@ describe('Developmental Window System', () => {
       // Week-old foal - early socialization window
       prisma.horse.create({
         data: {
-          name: `Test Foal Week ${Date.now()}`,
+          name: `Test Foal Week ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'colt',
           dateOfBirth: oneWeekAgo,
           userId: testUser.id,
@@ -100,7 +100,7 @@ describe('Developmental Window System', () => {
       // Two-week-old foal - fear period window
       prisma.horse.create({
         data: {
-          name: `Test Foal TwoWeek ${Date.now()}`,
+          name: `Test Foal TwoWeek ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'filly',
           dateOfBirth: twoWeeksAgo,
           userId: testUser.id,
@@ -112,7 +112,7 @@ describe('Developmental Window System', () => {
       // Month-old foal - curiosity development window
       prisma.horse.create({
         data: {
-          name: `Test Foal Month ${Date.now()}`,
+          name: `Test Foal Month ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'gelding',
           dateOfBirth: oneMonthAgo,
           userId: testUser.id,
@@ -124,7 +124,7 @@ describe('Developmental Window System', () => {
       // Three-month-old foal - independence development
       prisma.horse.create({
         data: {
-          name: `Test Foal ThreeMonth ${Date.now()}`,
+          name: `Test Foal ThreeMonth ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'colt',
           dateOfBirth: threeMonthsAgo,
           userId: testUser.id,

--- a/backend/tests/services/dynamicCompatibilityScoring.test.mjs
+++ b/backend/tests/services/dynamicCompatibilityScoring.test.mjs
@@ -37,8 +37,8 @@ describe('Dynamic Compatibility Scoring', () => {
       // Create test user
       testUser = await tx.user.create({
         data: {
-          username: `compatibility_${Date.now()}`,
-          email: `compatibility_${Date.now()}@test.com`,
+          username: `compatibility_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+          email: `compatibility_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
           password: 'test_hash',
           firstName: 'Test',
           lastName: 'User',
@@ -53,7 +53,7 @@ describe('Dynamic Compatibility Scoring', () => {
         // Expert calm groom
         tx.groom.create({
           data: {
-            name: `Expert Calm Groom ${Date.now()}`,
+            name: `Expert Calm Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             personality: 'calm',
             epigeneticInfluenceType: 'calm',
             skillLevel: 'expert',
@@ -67,7 +67,7 @@ describe('Dynamic Compatibility Scoring', () => {
         // Novice energetic groom
         tx.groom.create({
           data: {
-            name: `Novice Energetic Groom ${Date.now()}`,
+            name: `Novice Energetic Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             personality: 'energetic',
             epigeneticInfluenceType: 'energetic',
             skillLevel: 'novice',
@@ -81,7 +81,7 @@ describe('Dynamic Compatibility Scoring', () => {
         // Experienced methodical groom
         tx.groom.create({
           data: {
-            name: `Experienced Methodical Groom ${Date.now()}`,
+            name: `Experienced Methodical Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             personality: 'methodical',
             epigeneticInfluenceType: 'methodical',
             skillLevel: 'experienced',
@@ -98,7 +98,7 @@ describe('Dynamic Compatibility Scoring', () => {
         // High-stress fearful horse
         tx.horse.create({
           data: {
-            name: `Test Horse Fearful ${Date.now()}`,
+            name: `Test Horse Fearful ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             sex: 'filly',
             dateOfBirth: oneMonthAgo,
             userId: testUser.id,
@@ -110,7 +110,7 @@ describe('Dynamic Compatibility Scoring', () => {
         // Confident social horse
         tx.horse.create({
           data: {
-            name: `Test Horse Confident ${Date.now()}`,
+            name: `Test Horse Confident ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             sex: 'colt',
             dateOfBirth: oneMonthAgo,
             userId: testUser.id,
@@ -122,7 +122,7 @@ describe('Dynamic Compatibility Scoring', () => {
         // Moderate temperament horse
         tx.horse.create({
           data: {
-            name: `Test Horse Moderate ${Date.now()}`,
+            name: `Test Horse Moderate ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             sex: 'gelding',
             dateOfBirth: oneMonthAgo,
             userId: testUser.id,

--- a/backend/tests/services/environmentalTriggerSystem.test.mjs
+++ b/backend/tests/services/environmentalTriggerSystem.test.mjs
@@ -43,8 +43,8 @@ describe('Environmental Trigger System', () => {
       // Create test user
       testUser = await tx.user.create({
         data: {
-          username: `env_trigger_${Date.now()}`,
-          email: `env_trigger_${Date.now()}@test.com`,
+          username: `env_trigger_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+          email: `env_trigger_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
           password: 'test_hash',
           firstName: 'Test',
           lastName: 'User',
@@ -58,7 +58,7 @@ describe('Environmental Trigger System', () => {
       testGrooms = await Promise.all([
         tx.groom.create({
           data: {
-            name: `Calm Groom ${Date.now()}`,
+            name: `Calm Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             personality: 'calm',
             epigeneticInfluenceType: 'calm',
             skillLevel: 'expert',
@@ -71,7 +71,7 @@ describe('Environmental Trigger System', () => {
         }),
         tx.groom.create({
           data: {
-            name: `Energetic Groom ${Date.now()}`,
+            name: `Energetic Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             personality: 'energetic',
             epigeneticInfluenceType: 'energetic',
             skillLevel: 'expert',
@@ -88,7 +88,7 @@ describe('Environmental Trigger System', () => {
         // Young foal - high environmental sensitivity
         tx.horse.create({
           data: {
-            name: `Test Foal Young ${Date.now()}`,
+            name: `Test Foal Young ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             sex: 'filly',
             dateOfBirth: oneWeekAgo,
             userId: testUser.id,
@@ -100,7 +100,7 @@ describe('Environmental Trigger System', () => {
         // Older foal - moderate sensitivity
         tx.horse.create({
           data: {
-            name: `Test Foal Older ${Date.now()}`,
+            name: `Test Foal Older ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             sex: 'colt',
             dateOfBirth: oneMonthAgo,
             userId: testUser.id,
@@ -112,7 +112,7 @@ describe('Environmental Trigger System', () => {
         // Stressed foal - high trigger sensitivity
         tx.horse.create({
           data: {
-            name: `Test Foal Stressed ${Date.now()}`,
+            name: `Test Foal Stressed ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             sex: 'filly',
             dateOfBirth: twoWeeksAgo,
             userId: testUser.id,

--- a/backend/tests/services/flagAssignmentEngineEnhanced.test.mjs
+++ b/backend/tests/services/flagAssignmentEngineEnhanced.test.mjs
@@ -37,8 +37,8 @@ describe('Enhanced Flag Assignment Engine', () => {
       // Create test user
       testUser = await tx.user.create({
         data: {
-          username: `flagengine_${Date.now()}`,
-          email: `flagengine_${Date.now()}@test.com`,
+          username: `flagengine_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+          email: `flagengine_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
           password: 'test_hash',
           firstName: 'Test',
           lastName: 'User',
@@ -52,7 +52,7 @@ describe('Enhanced Flag Assignment Engine', () => {
       testGrooms = await Promise.all([
         tx.groom.create({
           data: {
-            name: `Test Groom Calm ${Date.now()}`,
+            name: `Test Groom Calm ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             personality: 'calm',
             epigeneticInfluenceType: 'calm',
             skillLevel: 'experienced',
@@ -63,7 +63,7 @@ describe('Enhanced Flag Assignment Engine', () => {
         }),
         tx.groom.create({
           data: {
-            name: `Test Groom Energetic ${Date.now()}`,
+            name: `Test Groom Energetic ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             personality: 'energetic',
             epigeneticInfluenceType: 'energetic',
             skillLevel: 'experienced',
@@ -74,7 +74,7 @@ describe('Enhanced Flag Assignment Engine', () => {
         }),
         tx.groom.create({
           data: {
-            name: `Test Groom Methodical ${Date.now()}`,
+            name: `Test Groom Methodical ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             personality: 'methodical',
             epigeneticInfluenceType: 'methodical',
             skillLevel: 'expert',
@@ -89,7 +89,7 @@ describe('Enhanced Flag Assignment Engine', () => {
         // Very young foal (1 week) - high sensitivity to triggers
         tx.horse.create({
           data: {
-            name: `Test Foal Week ${Date.now()}`,
+            name: `Test Foal Week ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             sex: 'filly',
             dateOfBirth: oneWeekAgo,
             userId: testUser.id,
@@ -101,7 +101,7 @@ describe('Enhanced Flag Assignment Engine', () => {
         // Young foal (1 month) - moderate sensitivity
         tx.horse.create({
           data: {
-            name: `Test Foal Month ${Date.now()}`,
+            name: `Test Foal Month ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             sex: 'colt',
             dateOfBirth: oneMonthAgo,
             userId: testUser.id,
@@ -113,7 +113,7 @@ describe('Enhanced Flag Assignment Engine', () => {
         // Older foal (6 months) - lower sensitivity
         tx.horse.create({
           data: {
-            name: `Test Foal 6mo ${Date.now()}`,
+            name: `Test Foal 6mo ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             sex: 'gelding',
             dateOfBirth: sixMonthsAgo,
             userId: testUser.id,

--- a/backend/tests/services/groomLegacyService.test.mjs
+++ b/backend/tests/services/groomLegacyService.test.mjs
@@ -23,7 +23,7 @@ describe('Groom Legacy Service', () => {
   let testUser;
   let testHorse;
   let retiredGroom;
-  const testRunId = `legacy_${Date.now()}_${Math.floor(Math.random() * 100000)}`;
+  const testRunId = `legacy_${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.floor(Math.random() * 100000)}`;
   const testUserData = {
     username: `testuser_legacy_${testRunId}`,
     email: `test_legacy_${testRunId}@example.com`,
@@ -73,7 +73,7 @@ describe('Groom Legacy Service', () => {
     // Create a retired high-level groom for each test
     retiredGroom = await prisma.groom.create({
       data: {
-        name: `Retired Master Groom ${Date.now()}`,
+        name: `Retired Master Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         personality: 'calm',
         skillLevel: 'expert',
         speciality: 'foal_care',
@@ -165,7 +165,7 @@ describe('Groom Legacy Service', () => {
       // Create active groom
       const activeGroom = await prisma.groom.create({
         data: {
-          name: `Active Groom ${Date.now()}`,
+          name: `Active Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           personality: 'energetic',
           skillLevel: 'expert',
           speciality: 'general_grooming',
@@ -188,7 +188,7 @@ describe('Groom Legacy Service', () => {
       // Create low-level retired groom
       const lowLevelGroom = await prisma.groom.create({
         data: {
-          name: `Low Level Groom ${Date.now()}`,
+          name: `Low Level Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           personality: 'methodical',
           skillLevel: 'intermediate',
           speciality: 'specialized_disciplines',
@@ -212,7 +212,7 @@ describe('Groom Legacy Service', () => {
       // Create a protégé first
       const protege = await prisma.groom.create({
         data: {
-          name: `Existing Protégé ${Date.now()}`,
+          name: `Existing Protégé ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           personality: 'calm',
           skillLevel: 'novice',
           speciality: 'foal_care',
@@ -280,7 +280,7 @@ describe('Groom Legacy Service', () => {
       // Create ineligible groom
       const ineligibleGroom = await prisma.groom.create({
         data: {
-          name: `Ineligible Groom ${Date.now()}`,
+          name: `Ineligible Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           personality: 'calm',
           skillLevel: 'novice',
           speciality: 'foal_care',

--- a/backend/tests/services/groomPersonalityTraits.test.mjs
+++ b/backend/tests/services/groomPersonalityTraits.test.mjs
@@ -36,8 +36,8 @@ describe('Groom Personality Trait System', () => {
       // Create test user
       testUser = await tx.user.create({
         data: {
-          username: `groomtraits_${Date.now()}`,
-          email: `groomtraits_${Date.now()}@test.com`,
+          username: `groomtraits_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+          email: `groomtraits_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
           password: 'test_hash',
           firstName: 'Test',
           lastName: 'User',
@@ -52,7 +52,7 @@ describe('Groom Personality Trait System', () => {
         // Calm personality groom
         tx.groom.create({
           data: {
-            name: `Calm Expert Groom ${Date.now()}`,
+            name: `Calm Expert Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             personality: 'calm',
             epigeneticInfluenceType: 'calm',
             skillLevel: 'expert',
@@ -66,7 +66,7 @@ describe('Groom Personality Trait System', () => {
         // Energetic personality groom
         tx.groom.create({
           data: {
-            name: `Energetic Novice Groom ${Date.now()}`,
+            name: `Energetic Novice Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             personality: 'energetic',
             epigeneticInfluenceType: 'energetic',
             skillLevel: 'novice',
@@ -80,7 +80,7 @@ describe('Groom Personality Trait System', () => {
         // Methodical personality groom
         tx.groom.create({
           data: {
-            name: `Methodical Experienced Groom ${Date.now()}`,
+            name: `Methodical Experienced Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             personality: 'methodical',
             epigeneticInfluenceType: 'methodical',
             skillLevel: 'experienced',
@@ -97,7 +97,7 @@ describe('Groom Personality Trait System', () => {
         // Nervous/fearful horse
         tx.horse.create({
           data: {
-            name: `Test Horse Nervous ${Date.now()}`,
+            name: `Test Horse Nervous ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             sex: 'filly',
             dateOfBirth: oneMonthAgo,
             userId: testUser.id,
@@ -109,7 +109,7 @@ describe('Groom Personality Trait System', () => {
         // Confident/brave horse
         tx.horse.create({
           data: {
-            name: `Test Horse Confident ${Date.now()}`,
+            name: `Test Horse Confident ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             sex: 'colt',
             dateOfBirth: oneMonthAgo,
             userId: testUser.id,
@@ -121,7 +121,7 @@ describe('Groom Personality Trait System', () => {
         // Neutral horse
         tx.horse.create({
           data: {
-            name: `Test Horse Neutral ${Date.now()}`,
+            name: `Test Horse Neutral ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             sex: 'gelding',
             dateOfBirth: oneMonthAgo,
             userId: testUser.id,

--- a/backend/tests/services/groomRetirementService.test.mjs
+++ b/backend/tests/services/groomRetirementService.test.mjs
@@ -32,8 +32,8 @@ describe('Groom Retirement Service', () => {
     // Create test user
     testUser = await prisma.user.create({
       data: {
-        username: `testuser_retirement_${Date.now()}`,
-        email: `test_retirement_${Date.now()}@example.com`,
+        username: `testuser_retirement_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `test_retirement_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
         password: 'hashedpassword123',
         firstName: 'Test',
         lastName: 'User',
@@ -43,7 +43,7 @@ describe('Groom Retirement Service', () => {
     // Create test horse for assignment logs
     testHorse = await prisma.horse.create({
       data: {
-        name: `Test Horse ${Date.now()}`,
+        name: `Test Horse ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         sex: 'male',
         dateOfBirth: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000), // 1 year old
         userId: testUser.id,
@@ -57,7 +57,7 @@ describe('Groom Retirement Service', () => {
     // Create fresh test groom for each test
     testGroom = await prisma.groom.create({
       data: {
-        name: `Test Groom ${Date.now()}`,
+        name: `Test Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         personality: 'calm',
         skillLevel: 'intermediate',
         speciality: 'foal_care',
@@ -297,7 +297,7 @@ describe('Groom Retirement Service', () => {
       testGrooms = await Promise.all([
         prisma.groom.create({
           data: {
-            name: `Test Groom Early ${Date.now()}`,
+            name: `Test Groom Early ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             personality: 'calm',
             skillLevel: 'novice',
             speciality: 'foal_care',
@@ -309,7 +309,7 @@ describe('Groom Retirement Service', () => {
         }),
         prisma.groom.create({
           data: {
-            name: `Test Groom Mid ${Date.now()}`,
+            name: `Test Groom Mid ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             personality: 'energetic',
             skillLevel: 'intermediate',
             speciality: 'general_grooming',
@@ -321,7 +321,7 @@ describe('Groom Retirement Service', () => {
         }),
         prisma.groom.create({
           data: {
-            name: `Test Groom Near Retirement ${Date.now()}`,
+            name: `Test Groom Near Retirement ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             personality: 'methodical',
             skillLevel: 'expert',
             speciality: 'specialized_disciplines',
@@ -333,7 +333,7 @@ describe('Groom Retirement Service', () => {
         }),
         prisma.groom.create({
           data: {
-            name: `Test Groom Level 10 ${Date.now()}`,
+            name: `Test Groom Level 10 ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
             personality: 'calm',
             skillLevel: 'expert',
             speciality: 'foal_care',
@@ -401,7 +401,7 @@ describe('Groom Retirement Service', () => {
       // Create a groom that will cause an error during processing by making it invalid after creation
       const problemGroom = await prisma.groom.create({
         data: {
-          name: `Problem Groom ${Date.now()}`,
+          name: `Problem Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           personality: 'calm',
           skillLevel: 'novice',
           speciality: 'foal_care',

--- a/backend/tests/services/groomTalentService.test.mjs
+++ b/backend/tests/services/groomTalentService.test.mjs
@@ -26,7 +26,7 @@ describe('Groom Talent Service', () => {
   let testGroom;
 
   beforeEach(async () => {
-    const testSuffix = `${Date.now()}_${Math.random().toString(16).slice(2, 8)}`;
+    const testSuffix = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(16).slice(2, 8)}`;
 
     testUser = await prisma.user.create({
       data: {
@@ -121,7 +121,7 @@ describe('Groom Talent Service', () => {
       // Create low-level groom
       const lowLevelGroom = await prisma.groom.create({
         data: {
-          name: `Low Level Groom ${Date.now()}`,
+          name: `Low Level Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           personality: 'calm',
           skillLevel: 'novice',
           speciality: 'foal_care',
@@ -214,7 +214,7 @@ describe('Groom Talent Service', () => {
       // Create low-level groom
       const lowLevelGroom = await prisma.groom.create({
         data: {
-          name: `Low Level Groom ${Date.now()}`,
+          name: `Low Level Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           personality: 'calm',
           skillLevel: 'novice',
           speciality: 'foal_care',

--- a/backend/tests/services/horseTemperamentAnalysis.test.mjs
+++ b/backend/tests/services/horseTemperamentAnalysis.test.mjs
@@ -32,8 +32,8 @@ describe('Horse Temperament Analysis', () => {
     // Create test user
     testUser = await prisma.user.create({
       data: {
-        username: `temperament_${Date.now()}`,
-        email: `temperament_${Date.now()}@test.com`,
+        username: `temperament_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `temperament_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
         password: 'test_hash',
         firstName: 'Test',
         lastName: 'User',
@@ -47,7 +47,7 @@ describe('Horse Temperament Analysis', () => {
     testGrooms = await Promise.all([
       prisma.groom.create({
         data: {
-          name: `Calm Groom ${Date.now()}`,
+          name: `Calm Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           personality: 'calm',
           epigeneticInfluenceType: 'calm',
           skillLevel: 'expert',
@@ -58,7 +58,7 @@ describe('Horse Temperament Analysis', () => {
       }),
       prisma.groom.create({
         data: {
-          name: `Energetic Groom ${Date.now()}`,
+          name: `Energetic Groom ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           personality: 'energetic',
           epigeneticInfluenceType: 'energetic',
           skillLevel: 'expert',
@@ -77,7 +77,7 @@ describe('Horse Temperament Analysis', () => {
       // Nervous/reactive horse
       prisma.horse.create({
         data: {
-          name: `Test Horse Nervous ${Date.now()}`,
+          name: `Test Horse Nervous ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'filly',
           dateOfBirth: oneMonthAgo,
           userId: testUser.id,
@@ -89,7 +89,7 @@ describe('Horse Temperament Analysis', () => {
       // Confident/social horse
       prisma.horse.create({
         data: {
-          name: `Test Horse Confident ${Date.now()}`,
+          name: `Test Horse Confident ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'colt',
           dateOfBirth: oneMonthAgo,
           userId: testUser.id,
@@ -101,7 +101,7 @@ describe('Horse Temperament Analysis', () => {
       // Mixed temperament horse
       prisma.horse.create({
         data: {
-          name: `Test Horse Mixed ${Date.now()}`,
+          name: `Test Horse Mixed ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'gelding',
           dateOfBirth: oneMonthAgo,
           userId: testUser.id,
@@ -113,7 +113,7 @@ describe('Horse Temperament Analysis', () => {
       // Developing temperament horse (no flags yet)
       prisma.horse.create({
         data: {
-          name: `Test Horse Developing ${Date.now()}`,
+          name: `Test Horse Developing ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'mare',
           dateOfBirth: oneMonthAgo,
           userId: testUser.id,

--- a/backend/tests/services/personalityEvolutionSystem.test.mjs
+++ b/backend/tests/services/personalityEvolutionSystem.test.mjs
@@ -47,8 +47,8 @@ describe('Personality Evolution System', () => {
       // Create test user
       testUser = await tx.user.create({
         data: {
-          username: `personality_evolution_${Date.now()}`,
-          email: `personality_evolution_${Date.now()}@test.com`,
+          username: `personality_evolution_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+          email: `personality_evolution_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
           password: 'test_hash',
           firstName: 'Test',
           lastName: 'User',
@@ -61,7 +61,7 @@ describe('Personality Evolution System', () => {
       // Create test breed
       testBreed = await tx.breed.create({
         data: {
-          name: `Test Breed ${Date.now()}`,
+          name: `Test Breed ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           description: 'Test breed for personality evolution testing',
         },
       });

--- a/backend/tests/services/traitInteractionMatrix.test.mjs
+++ b/backend/tests/services/traitInteractionMatrix.test.mjs
@@ -32,7 +32,7 @@ describe('Trait Interaction Matrix', () => {
   let testHorses = [];
 
   const createTraitTestData = async () => {
-    const testSuffix = `${Date.now()}_${Math.random().toString(16).slice(2, 8)}`;
+    const testSuffix = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(16).slice(2, 8)}`;
     testUser = await prisma.user.create({
       data: {
         username: `trait_matrix_${testSuffix}`,

--- a/backend/tests/services/weeklyFlagEvaluationService.test.mjs
+++ b/backend/tests/services/weeklyFlagEvaluationService.test.mjs
@@ -28,8 +28,8 @@ describe('Weekly Flag Evaluation Service', () => {
     // Create test user
     testUser = await prisma.user.create({
       data: {
-        username: `flagtest_${Date.now()}`,
-        email: `flagtest_${Date.now()}@test.com`,
+        username: `flagtest_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+        email: `flagtest_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@test.com`,
         password: 'test_hash',
         firstName: 'Test',
         lastName: 'User',
@@ -43,7 +43,7 @@ describe('Weekly Flag Evaluation Service', () => {
     testGrooms = await Promise.all([
       prisma.groom.create({
         data: {
-          name: `Test Groom Calm ${Date.now()}`,
+          name: `Test Groom Calm ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           personality: 'calm',
           epigeneticInfluenceType: 'calm',
           skillLevel: 'experienced',
@@ -54,7 +54,7 @@ describe('Weekly Flag Evaluation Service', () => {
       }),
       prisma.groom.create({
         data: {
-          name: `Test Groom Energetic ${Date.now()}`,
+          name: `Test Groom Energetic ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           personality: 'energetic',
           epigeneticInfluenceType: 'energetic',
           skillLevel: 'experienced',
@@ -76,7 +76,7 @@ describe('Weekly Flag Evaluation Service', () => {
       // Young foal (1 week old) - eligible for flag evaluation
       prisma.horse.create({
         data: {
-          name: `Test Foal Week ${Date.now()}`,
+          name: `Test Foal Week ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'filly',
           dateOfBirth: oneWeekAgo,
           userId: testUser.id,
@@ -88,7 +88,7 @@ describe('Weekly Flag Evaluation Service', () => {
       // Young horse (1 month old) - eligible for flag evaluation
       prisma.horse.create({
         data: {
-          name: `Test Foal Month ${Date.now()}`,
+          name: `Test Foal Month ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'colt',
           dateOfBirth: oneMonthAgo,
           userId: testUser.id,
@@ -100,7 +100,7 @@ describe('Weekly Flag Evaluation Service', () => {
       // 2-year-old horse - still eligible for flag evaluation
       prisma.horse.create({
         data: {
-          name: `Test Horse 2yo ${Date.now()}`,
+          name: `Test Horse 2yo ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'gelding',
           dateOfBirth: twoYearsAgo,
           userId: testUser.id,
@@ -112,7 +112,7 @@ describe('Weekly Flag Evaluation Service', () => {
       // 4-year-old horse - NOT eligible for flag evaluation
       prisma.horse.create({
         data: {
-          name: `Test Horse 4yo ${Date.now()}`,
+          name: `Test Horse 4yo ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'mare',
           dateOfBirth: fourYearsAgo,
           userId: testUser.id,
@@ -198,7 +198,7 @@ describe('Weekly Flag Evaluation Service', () => {
       // Create a horse with 5 flags already
       const horseWithMaxFlags = await prisma.horse.create({
         data: {
-          name: `Test Horse Max Flags ${Date.now()}`,
+          name: `Test Horse Max Flags ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
           sex: 'filly',
           dateOfBirth: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000), // 1 month old
           userId: testUser.id,

--- a/backend/tests/training-updated.test.mjs
+++ b/backend/tests/training-updated.test.mjs
@@ -75,7 +75,7 @@ describe('🏋️ INTEGRATION: Training System Updated - User Model Integration'
   beforeAll(async () => {
     // Use 'trainupd_' prefix — not matched by cleanupTestData's 'testuser_' pattern,
     // so parallel suites calling cleanupTestData won't wipe this suite's data.
-    const ts = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const ts = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).slice(2, 8)}`;
     const hashedPw = await bcrypt.hash('TestPassword123!', 10);
     const user = await prisma.user.create({
       data: {

--- a/backend/tests/trainingCooldown.test.mjs
+++ b/backend/tests/trainingCooldown.test.mjs
@@ -75,7 +75,7 @@ describe('⏰ UNIT: Training Cooldown System - Horse Training Restrictions', () 
     // Mock test horse
     testHorse = {
       id: 1,
-      name: `Test Training Horse ${Date.now()}`,
+      name: `Test Training Horse ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
       age: 5,
       breedId: testBreed.id,
       sex: 'Mare',

--- a/backend/tests/traitDiscoveryIntegration.test.mjs
+++ b/backend/tests/traitDiscoveryIntegration.test.mjs
@@ -42,7 +42,7 @@ describe('Trait Discovery API Integration Tests', () => {
     });
 
     // Create test breed with unique name
-    const uniqueName = `Test Breed for Trait Discovery ${Date.now()}`;
+    const uniqueName = `Test Breed for Trait Discovery ${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
     testBreed = await prisma.breed.create({
       data: {
         name: uniqueName,

--- a/backend/tests/traitMilestoneIntegration.test.mjs
+++ b/backend/tests/traitMilestoneIntegration.test.mjs
@@ -86,7 +86,7 @@ describe('Trait Milestone Integration', () => {
     await cleanupTestData();
 
     // Create test user with unique identifiers
-    const suffix = `${Date.now()}_${Math.random().toString(36).substr(2, 5)}`;
+    const suffix = `${Date.now()}_${Math.random().toString(36).slice(2, 6)}_${Math.random().toString(36).substr(2, 5)}`;
     testUser = await prisma.user.create({
       data: {
         id: `user-milestone-${suffix}`,

--- a/backend/tests/traitTimeline.test.mjs
+++ b/backend/tests/traitTimeline.test.mjs
@@ -40,7 +40,7 @@ describe('Trait Timeline System', () => {
     // Create test breed
     testBreed = await prisma.breed.create({
       data: {
-        name: `TestBreed_${Date.now()}`,
+        name: `TestBreed_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         description: 'Test breed for trait timeline tests',
       },
     });
@@ -48,10 +48,10 @@ describe('Trait Timeline System', () => {
     // Create test user
     testUser = await prisma.user.create({
       data: {
-        username: `testuser_${Date.now()}`,
+        username: `testuser_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         firstName: 'Test',
         lastName: 'User',
-        email: `test_${Date.now()}@example.com`,
+        email: `test_${Date.now()}_${Math.random().toString(36).slice(2, 6)}@example.com`,
         password: 'hashedpassword',
         money: 10000,
         xp: 100,
@@ -62,7 +62,7 @@ describe('Trait Timeline System', () => {
     // Create test groom
     testGroom = await prisma.groom.create({
       data: {
-        name: `TestGroom_${Date.now()}`,
+        name: `TestGroom_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         speciality: 'foal_care',
         experience: 10,
         skillLevel: 'expert',
@@ -76,7 +76,7 @@ describe('Trait Timeline System', () => {
     // Create test horse (3 years old)
     testHorse = await prisma.horse.create({
       data: {
-        name: `TestHorse_${Date.now()}`,
+        name: `TestHorse_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
         sex: 'stallion',
         dateOfBirth: new Date(Date.now() - 3 * 365 * 24 * 60 * 60 * 1000), // 3 years old
         temperament: 'spirited',


### PR DESCRIPTION
Equoria-3iyk Phase 3a — test hygiene sweep, first pass.

## What this fixes

79 test files used bare `\${Date.now()}` in fixture names (emails, usernames, horse names, breed names, token names). When two tests fire `prisma.create()` in the same millisecond — common under parallel CI shards or back-to-back beforeEach hooks — the unique constraint on those fields fires P2002. This was the **groomBonusTraits TestBreed_ collisions** in PR #99 and **dozens of intermittent CI flakes** over the last ~6 months.

## What changed

Bulk replacement: every `\${Date.now()}` template-literal expression becomes `\${Date.now()}_\${Math.random().toString(36).slice(2,6)}`.

- 257 occurrences across 79 files
- Pure rename, no logic change
- Suffix length 4 (not 8) — some validators cap username at 30 chars; 8-char version pushed `cookietest\${ts}_\${8chars}` to 32, blowing past validation. 4 chars gives ~1.6M values per millisecond, well above any realistic collision rate.

## What this does NOT fix

Hardcoded test emails / usernames that survive across runs:
- `xss-test@example.com`, `cookietest@example.com`, `sessiontest@example.com`, `e2e@test.com`, etc.

These need a per-suite prefix-based cleanup convention in beforeAll, applied systematically rather than the case-by-case fixes in PR #99. Separate Phase 3b PR.

## Test plan

- [x] auth-cookies (17/17) — was the 30-char-limit canary
- [x] security/* — 7 suites / 158 tests
- [x] csrf-integration, auth-password-reset, input-validation, auth-bypass-attempts, owasp-comprehensive, ownership-violations — all green in a single --runInBand run
- [ ] CI runs Backend Tests Shards 1-3, Coverage Gate, Integration Tests on this PR — required for merge per branch protection
- [ ] After merge, CI flake rate on master should drop noticeably for any test that creates DB rows in beforeEach

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test data generation across backend test suites to reduce identifier collisions during parallel or rapid test execution by enhancing randomness in generated test values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->