### PR TITLE
chore(tests): Phase 3c — middleware-vs-test drift audit

### DIFF
--- a/backend/__tests__/integration/cookieIntegration.test.mjs
+++ b/backend/__tests__/integration/cookieIntegration.test.mjs
@@ -30,7 +30,11 @@ describe('Cookie Integration Tests', () => {
   // crashed prior runs (Phase 3b).
   const SUITE_PREFIX = 'cintg';
   let testUser;
-  const rateLimitBypassHeader = { 'X-Test-Bypass-Rate-Limit': 'true', 'X-Test-Bypass-Auth': 'true' };
+  // Test-bypass headers were purged from production middleware in commits
+  // 5a158681 / 3590916e. Empty object preserves `.set(rateLimitBypassHeader)`
+  // call-site signatures with no behavior. Rate pressure in test env is
+  // governed by TEST_RATE_LIMIT_* env knobs (see middleware/rateLimiting.mjs).
+  const rateLimitBypassHeader = {};
 
   const cleanSuite = async () => {
     const stale = await prisma.user.findMany({

--- a/backend/__tests__/integration/rate-limit-circuit-breaker.test.mjs
+++ b/backend/__tests__/integration/rate-limit-circuit-breaker.test.mjs
@@ -197,29 +197,15 @@ describe('Rate Limiting Circuit Breaker Integration Tests', () => {
   });
 
   describe('Test Environment Bypasses', () => {
-    it('should bypass rate limiting with test header', async () => {
-      const limiter = createRateLimiter({
-        windowMs: 1000,
-        max: 1, // Very restrictive
-        keyPrefix: 'bypass-test',
-      });
-
-      // Make many requests with bypass header (each with new request object)
-      for (let i = 0; i < 5; i++) {
-        const req = createMockRequest({
-          headers: {
-            'x-test-bypass-rate-limit': 'true',
-          },
-        });
-        const res = createMockResponse();
-        const next = jest.fn();
-
-        limiter(req, res, next);
-        await new Promise(resolve => setTimeout(resolve, 10));
-
-        expect(next).toHaveBeenCalled();
-      }
-    });
+    // The previous "should bypass rate limiting with test header" test was
+    // removed in Phase 3c: header-based bypass logic was purged from
+    // production middleware (commits 5a158681 / 3590916e), and the
+    // mock-based assertion `expect(next).toHaveBeenCalled()` was passing
+    // for the wrong reason — synthetic mocks never fully invoke the
+    // express-rate-limit counter, so next() fires regardless of the
+    // header. The real contract is now: rate pressure in test env is
+    // controlled by TEST_RATE_LIMIT_WINDOW_MS / TEST_RATE_LIMIT_MAX_REQUESTS
+    // env vars when useEnvOverride is set on the limiter (see test below).
 
     it('should respect test environment overrides', async () => {
       // Test uses environment variable overrides

--- a/backend/__tests__/integration/register-starter-horse.test.mjs
+++ b/backend/__tests__/integration/register-starter-horse.test.mjs
@@ -18,7 +18,11 @@ import app from '../../app.mjs';
 import prisma from '../../db/index.mjs';
 
 import { fetchCsrf } from '../../tests/helpers/csrfHelper.mjs';
-const rateLimitBypass = { 'X-Test-Bypass-Rate-Limit': 'true' };
+// Test-bypass headers were purged from production middleware in commits
+// 5a158681 / 3590916e. Empty object preserves `.set(rateLimitBypass)`
+// call-site signatures with no behavior. Rate pressure in test env is
+// governed by TEST_RATE_LIMIT_* env knobs (see middleware/rateLimiting.mjs).
+const rateLimitBypass = {};
 
 describe('POST /api/auth/register — starter horse integration', () => {
   let __csrf__;

--- a/backend/__tests__/integration/token-rotation.test.mjs
+++ b/backend/__tests__/integration/token-rotation.test.mjs
@@ -32,7 +32,11 @@ describe('Token Rotation and Reuse Detection System', () => {
   let testUser;
   let testPassword;
   let server;
-  const rateLimitBypassHeader = { 'X-Test-Bypass-Rate-Limit': 'true', 'X-Test-Bypass-Auth': 'true' };
+  // Test-bypass headers were purged from production middleware in commits
+  // 5a158681 / 3590916e. Empty object preserves `.set(rateLimitBypassHeader)`
+  // call-site signatures with no behavior. Rate pressure in test env is
+  // governed by TEST_RATE_LIMIT_* env knobs (see middleware/rateLimiting.mjs).
+  const rateLimitBypassHeader = {};
 
   beforeAll(async () => {
     // Start server once for all tests


### PR DESCRIPTION
## Summary

Audited tests against last 30 days of middleware/auth changes. Two real drift cases found and fixed.

## Drift 1 — Dead `X-Test-Bypass-*` header constants

Production middleware purged all header-based bypass logic in commits `5a158681` / `3590916e` (Story 21S-2 / Workstream 4). Three integration suites still defined `rateLimitBypassHeader` / `rateLimitBypass` constants containing `X-Test-Bypass-Rate-Limit` and `X-Test-Bypass-Auth`, which the middleware no longer reads:

- `backend/__tests__/integration/cookieIntegration.test.mjs`
- `backend/__tests__/integration/token-rotation.test.mjs`
- `backend/__tests__/integration/register-starter-horse.test.mjs`

Constants are now `{}` so existing `.set(rateLimitBypassHeader)` call-site signatures keep chaining with no behavior. Test env governs rate pressure via `TEST_RATE_LIMIT_*` env knobs (see `middleware/rateLimiting.mjs:273-276`).

## Drift 2 — Fake-pass test in `rate-limit-circuit-breaker.test.mjs`

The test \"should bypass rate limiting with test header\" asserted that `x-test-bypass-rate-limit` causes `next()` to fire for 5 requests under a max=1 limiter. But:

1. The header-based bypass branch was removed from the middleware.
2. The synthetic `createMockRequest`/`createMockResponse` mocks never fully invoke express-rate-limit's response-lifecycle counter — so `next()` always fires regardless of the header.

The test was passing for the wrong reason while implying a feature that doesn't exist. **Removed**, with a documenting comment pointing to the env-knob design. The sibling test \"should respect test environment overrides\" remains.

## Other 30-day middleware surfaces audited and confirmed clean

- **CSRF unification (`6da8925e`)** — `applyCsrfProtection` and `x-test-skip-csrf` fully purged from production and tests. The bulk test migration (`fa8f9db0`) handled it.
- **profileRateLimiter on onboarding (`d2b68d72`)** — tests pass through in test env at high limits; commit explicitly noted no test changes needed.
- **requireRole admin gate on `/api/memory` (`cfe0d35c`)** — `memoryManagementRoutes.test.mjs` already in sync (token signed with `role:'admin'`); the new `memoryAdminGuard.integration.test.mjs` covers the gate end-to-end.
- **Server-side NOW() for password reset expiry (`ab8b8909`)** — commit shipped its own integration test (`auth-password-reset.test.mjs`).
- **Token hashing (`38a04a24`)** — covered by PR #97 + Phase 0+1+2.

## Local verification

\`\`\`
Test Suites: 5 passed, 5 total
Tests:       78 passed, 78 total
\`\`\`

Lint clean.

## Test plan

- [ ] CI: Lint & Format green
- [ ] CI: Code Quality & Linting green
- [ ] CI: Backend Tests Shards 1-3 green
- [ ] CI: Integration Tests green
- [ ] CI: Backend Tests & Coverage green
- [ ] CI: Coverage Gate green
- [ ] CI: Backend/Frontend Cookie Auth green
- [ ] CI: Frontend Tests + Vitest green
- [ ] CI: Database Migration Check + Setup green
- [ ] CI: E2E Auth Flow green
- [ ] CI: OWASP ZAP API Security Scan green
- [ ] CI: Security Audit Cookie Configuration green
- [ ] CI: Security Scanning green
- [ ] CI: Build Validation green
- [ ] CI: CodeQL Analyze ×3 green
- [ ] CI: Dependency Security/Vuln scans green
- [ ] CI: claude-review green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated rate-limit testing strategy across integration tests to use environment variable configuration instead of request header-based bypass mechanisms.
  * Removed deprecated test header bypass functionality for rate-limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->