### PR TITLE
fix(21R-SEC): close CWE-613 access-token window via passwordChangedAt

### DIFF
--- a/backend/__tests__/integration/session-lifecycle.test.mjs
+++ b/backend/__tests__/integration/session-lifecycle.test.mjs
@@ -89,10 +89,15 @@ describe('Session Lifecycle Management', () => {
     });
 
     if (existing) {
-      if (existing.password !== hashedTestPassword) {
+      // Reset password AND passwordChangedAt every iteration. Without the
+      // passwordChangedAt reset, a prior test that successfully changed the
+      // password leaves a stale CWE-613 invalidation marker that causes
+      // freshly-issued tokens in subsequent tests to be rejected when they
+      // collide on the same second-precision iat boundary.
+      if (existing.password !== hashedTestPassword || existing.passwordChangedAt !== null) {
         testUser = await prisma.user.update({
           where: { id: existing.id },
-          data: { password: hashedTestPassword },
+          data: { password: hashedTestPassword, passwordChangedAt: null },
         });
       } else {
         testUser = existing;
@@ -740,6 +745,14 @@ describe('Session Lifecycle Management', () => {
       });
       expect(tokensBeforeChange).toBe(3);
 
+      // Sleep long enough to guarantee the next-second boundary crosses before
+      // the password change is stamped. JWT iat is second-precision, and the
+      // CWE-613 middleware check uses `iat < floor(passwordChangedAt / 1000)`;
+      // without this delay, a sub-second test run could leave the original
+      // tokens' iat in the same second as passwordChangedAt and the strong
+      // 401 assertion below would not fire deterministically.
+      await new Promise(resolve => setTimeout(resolve, 1100));
+
       // Step 3: Change password (invalidates all sessions)
       const newPassword = 'NewPassword456!';
       // 21R-AUTH-3: register/login/refresh now seed a CSRF cookie alongside
@@ -763,18 +776,31 @@ describe('Session Lifecycle Management', () => {
 
       expect(changePasswordResponse.body.data.sessionInvalidated).toBe(true);
 
-      // Step 4: Verify session invalidation took effect at the DB layer.
-      // NOTE: Access-token JWTs remain cryptographically valid until their
-      // 15-min expiry — closing that residual window requires a
-      // passwordChangedAt check in the JWT-verify path (Equoria-zgwl).
-      // Phase 3b's scope is fixture isolation only; this assertion verifies
-      // the invalidation behavior the system implements today:
-      // refresh-token cleanup. Restore the stronger 401 assertion when
-      // Equoria-zgwl lands.
+      // Step 4: Verify session invalidation took effect at both layers.
+      // (a) Refresh tokens for this user must be wiped — multi-session logout.
       const remainingTokens = await prisma.refreshToken.count({
         where: { userId: newUserId },
       });
       expect(remainingTokens).toBe(0);
+
+      // (b) CWE-613 strong assertion (Equoria-39r5): the access-token JWT
+      // issued before the password change must be rejected by authenticateToken,
+      // because the user's passwordChangedAt is now newer than the token's iat.
+      // This closes the residual ≤15-minute window where a stolen access token
+      // would otherwise outlive the password rotation.
+      // The variable `cookies` still holds the pre-change accessToken/refreshToken
+      // pair from registration; supertest does not auto-apply Set-Cookie clears
+      // from the change-password response, so resending these cookies exercises
+      // the exact "old token after password change" attack scenario.
+      const staleAccessTokenResponse = await request(app)
+        .get('/api/auth/profile')
+        .set('Origin', 'http://localhost:3000')
+        .set('Cookie', cookies)
+        .expect(401);
+      expect(staleAccessTokenResponse.body).toMatchObject({
+        success: false,
+        status: 'error',
+      });
 
       // Step 5: Login with new password
       const loginResponse = await request(app)

--- a/backend/__tests__/unit/security/token-validation.test.mjs
+++ b/backend/__tests__/unit/security/token-validation.test.mjs
@@ -39,33 +39,33 @@ describe('Token Validation Unit Tests', () => {
   });
 
   describe('Valid Token Scenarios', () => {
-    it('should authenticate with valid token in cookie', () => {
+    it('should authenticate with valid token in cookie', async () => {
       const user = createMockUser();
       const token = createMockToken(user.id);
 
       req.cookies.accessToken = token;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).toHaveBeenCalledWith();
       expect(req.user).toBeDefined();
       expect(req.user.id).toBe(user.id);
     });
 
-    it('should authenticate with valid token in Authorization header', () => {
+    it('should authenticate with valid token in Authorization header', async () => {
       const user = createMockUser();
       const token = createMockToken(user.id);
 
       req.headers.authorization = `Bearer ${token}`;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).toHaveBeenCalledWith();
       expect(req.user).toBeDefined();
       expect(req.user.id).toBe(user.id);
     });
 
-    it('should prefer cookie token over Authorization header', () => {
+    it('should prefer cookie token over Authorization header', async () => {
       const user1 = createMockUser({ id: 1 });
       const user2 = createMockUser({ id: 2 });
       const cookieToken = createMockToken(user1.id);
@@ -74,13 +74,13 @@ describe('Token Validation Unit Tests', () => {
       req.cookies.accessToken = cookieToken;
       req.headers.authorization = `Bearer ${headerToken}`;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).toHaveBeenCalledWith();
       expect(req.user.id).toBe(user1.id); // Should use cookie token
     });
 
-    it('should accept token with additional custom payload', () => {
+    it('should accept token with additional custom payload', async () => {
       const user = createMockUser();
       const token = createMockToken(user.id, {
         payload: {
@@ -91,7 +91,7 @@ describe('Token Validation Unit Tests', () => {
 
       req.cookies.accessToken = token;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).toHaveBeenCalledWith();
       expect(req.user.id).toBe(user.id);
@@ -101,13 +101,13 @@ describe('Token Validation Unit Tests', () => {
   });
 
   describe('Expired Token Scenarios', () => {
-    it('should reject expired token', () => {
+    it('should reject expired token', async () => {
       const user = createMockUser();
       const expiredToken = createMockToken(user.id, { expired: true });
 
       req.cookies.accessToken = expiredToken;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
@@ -118,7 +118,7 @@ describe('Token Validation Unit Tests', () => {
       });
     });
 
-    it('should reject token older than 7 days (CWE-613)', () => {
+    it('should reject token older than 7 days (CWE-613)', async () => {
       const user = createMockUser();
 
       // Create token with iat (issued at) from 8 days ago
@@ -133,7 +133,7 @@ describe('Token Validation Unit Tests', () => {
 
       req.cookies.accessToken = oldToken;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
@@ -144,7 +144,7 @@ describe('Token Validation Unit Tests', () => {
       });
     });
 
-    it('should accept token exactly 7 days old', () => {
+    it('should accept token exactly 7 days old', async () => {
       const user = createMockUser();
 
       // Create token with iat exactly 7 days ago
@@ -159,13 +159,13 @@ describe('Token Validation Unit Tests', () => {
 
       req.cookies.accessToken = sevenDayToken;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).toHaveBeenCalledWith();
       expect(req.user).toBeDefined();
     });
 
-    it('should reject token slightly over 7 days old', () => {
+    it('should reject token slightly over 7 days old', async () => {
       const user = createMockUser();
 
       // Create token just over 7 days old (7 days + 15 seconds, beyond 10s tolerance)
@@ -180,7 +180,7 @@ describe('Token Validation Unit Tests', () => {
 
       req.cookies.accessToken = justExpiredToken;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
@@ -188,10 +188,10 @@ describe('Token Validation Unit Tests', () => {
   });
 
   describe('Malformed Token Scenarios', () => {
-    it('should reject malformed token', () => {
+    it('should reject malformed token', async () => {
       req.cookies.accessToken = createMalformedToken();
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
@@ -202,13 +202,13 @@ describe('Token Validation Unit Tests', () => {
       });
     });
 
-    it('should reject token with invalid signature', () => {
+    it('should reject token with invalid signature', async () => {
       const user = createMockUser();
       const token = jwt.sign({ userId: user.id }, 'wrong-secret');
 
       req.cookies.accessToken = token;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
@@ -219,19 +219,19 @@ describe('Token Validation Unit Tests', () => {
       });
     });
 
-    it('should reject completely invalid token string', () => {
+    it('should reject completely invalid token string', async () => {
       req.cookies.accessToken = 'not-a-jwt-token';
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
     });
 
-    it('should reject empty token string', () => {
+    it('should reject empty token string', async () => {
       req.cookies.accessToken = '';
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
@@ -242,18 +242,18 @@ describe('Token Validation Unit Tests', () => {
       });
     });
 
-    it('should reject null token', () => {
+    it('should reject null token', async () => {
       req.cookies.accessToken = null;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
     });
 
-    it('should reject undefined token', () => {
+    it('should reject undefined token', async () => {
       // No token set at all
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
@@ -261,8 +261,8 @@ describe('Token Validation Unit Tests', () => {
   });
 
   describe('Missing Token Scenarios', () => {
-    it('should return 401 when no token in cookie or header', () => {
-      authenticateToken(req, res, next);
+    it('should return 401 when no token in cookie or header', async () => {
+      await authenticateToken(req, res, next);
 
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
@@ -273,32 +273,32 @@ describe('Token Validation Unit Tests', () => {
       });
     });
 
-    it('should return 401 when Authorization header has no Bearer token', () => {
+    it('should return 401 when Authorization header has no Bearer token', async () => {
       req.headers.authorization = 'Bearer ';
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
     });
 
-    it('should return 401 when Authorization header has wrong scheme', () => {
+    it('should return 401 when Authorization header has wrong scheme', async () => {
       const user = createMockUser();
       const token = createMockToken(user.id);
       req.headers.authorization = `Basic ${token}`;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
     });
 
-    it('should return 401 when Authorization header has no space', () => {
+    it('should return 401 when Authorization header has no space', async () => {
       const user = createMockUser();
       const token = createMockToken(user.id);
       req.headers.authorization = `Bearer${token}`; // Missing space
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
@@ -306,48 +306,48 @@ describe('Token Validation Unit Tests', () => {
   });
 
   describe('Token Payload Validation', () => {
-    it('should extract userId from token payload', () => {
+    it('should extract userId from token payload', async () => {
       const user = createMockUser({ id: 12345 });
       const token = createMockToken(user.id);
 
       req.cookies.accessToken = token;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(req.user.id).toBe(12345);
       expect(req.user.userId).toBe(12345);
     });
 
-    it('should handle legacy id field mapping', () => {
+    it('should handle legacy id field mapping', async () => {
       // Create token with id instead of userId
       const token = jwt.sign({ id: 99999 }, JWT_SECRET, { expiresIn: '15m' });
 
       req.cookies.accessToken = token;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(req.user.id).toBe(99999);
     });
 
-    it('should include iat (issued at) timestamp in user object', () => {
+    it('should include iat (issued at) timestamp in user object', async () => {
       const user = createMockUser();
       const token = createMockToken(user.id);
 
       req.cookies.accessToken = token;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(req.user.iat).toBeDefined();
       expect(typeof req.user.iat).toBe('number');
     });
 
-    it('should include exp (expiration) timestamp in user object', () => {
+    it('should include exp (expiration) timestamp in user object', async () => {
       const user = createMockUser();
       const token = createMockToken(user.id);
 
       req.cookies.accessToken = token;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(req.user.exp).toBeDefined();
       expect(typeof req.user.exp).toBe('number');
@@ -356,7 +356,7 @@ describe('Token Validation Unit Tests', () => {
   });
 
   describe('Security Edge Cases', () => {
-    it('should reject token with modified payload', () => {
+    it('should reject token with modified payload', async () => {
       const user = createMockUser({ id: 1 });
       const token = createMockToken(user.id);
 
@@ -370,7 +370,7 @@ describe('Token Validation Unit Tests', () => {
 
       req.cookies.accessToken = modifiedToken;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       const unauthorized = res.status.mock.calls.length > 0 || res.json.mock.calls.length > 0;
 
@@ -383,19 +383,19 @@ describe('Token Validation Unit Tests', () => {
       }
     });
 
-    it('should reject token without userId field', () => {
+    it('should reject token without userId field', async () => {
       const token = jwt.sign({ username: 'test' }, JWT_SECRET, { expiresIn: '15m' });
 
       req.cookies.accessToken = token;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       // Should still call next but req.user should handle missing userId gracefully
       expect(next).toHaveBeenCalledWith();
       expect(req.user.id).toBeUndefined();
     });
 
-    it('should reject token signed with algorithm none', () => {
+    it('should reject token signed with algorithm none', async () => {
       // Attempt to create token with algorithm 'none' (security vulnerability)
       const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64');
       const payload = Buffer.from(JSON.stringify({ userId: 1 })).toString('base64');
@@ -403,7 +403,7 @@ describe('Token Validation Unit Tests', () => {
 
       req.cookies.accessToken = noneToken;
 
-      authenticateToken(req, res, next);
+      await authenticateToken(req, res, next);
 
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);

--- a/backend/middleware/auth.mjs
+++ b/backend/middleware/auth.mjs
@@ -11,9 +11,12 @@ const suspiciousActivityCache = new Map();
 
 /**
  * JWT Authentication Middleware
- * Verifies JWT tokens and adds user information to request object
+ * Verifies JWT tokens and adds user information to request object.
+ * CWE-613 mitigation: rejects tokens whose `iat` predates the user's
+ * passwordChangedAt timestamp — closes the residual access-token-TTL window
+ * after a password rotation.
  */
-export const authenticateToken = (req, res, next) => {
+export const authenticateToken = async (req, res, next) => {
   const requestId = Math.random().toString(36).substring(7);
   logger.info(`[auth:${requestId}] Starting auth for ${req.method} ${req.path}`);
   try {
@@ -117,6 +120,46 @@ export const authenticateToken = (req, res, next) => {
       ...decoded,
       id: decoded.userId || decoded.id,
     };
+
+    // CWE-613 MITIGATION: reject access tokens issued before the user's
+    // last password rotation. Tokens are signed with iat in SECONDS; the DB
+    // column `passwordChangedAt` is millisecond-precision. We floor the DB
+    // value to whole seconds so a same-second login (iat = N) immediately
+    // after a password change at N.500 is still accepted — the granularity
+    // of iat means tokens issued anywhere within a single second are
+    // indistinguishable. The 1-second window of legacy-token validity at
+    // change time is the unavoidable cost of second-precision iat; in
+    // practice the user takes far longer than 1s to re-authenticate.
+    // Null `passwordChangedAt` (users who have never rotated) = no constraint.
+    // The User.id column is a string UUID — skip the lookup for non-string ids
+    // (forged or unit-test mock tokens). Downstream handlers will reject any
+    // malformed id when they try their own DB lookups.
+    if (decoded.iat && typeof user.id === 'string' && user.id.length > 0) {
+      try {
+        const dbUser = await prisma.user.findUnique({
+          where: { id: user.id },
+          select: { passwordChangedAt: true },
+        });
+        if (
+          dbUser &&
+          dbUser.passwordChangedAt &&
+          decoded.iat < Math.floor(dbUser.passwordChangedAt.getTime() / 1000)
+        ) {
+          logger.warn(
+            `[auth:${requestId}] Token rejected: iat predates passwordChangedAt for user ${user.id}`,
+          );
+          return respondUnauthorized('Session invalidated. Please login again.');
+        }
+      } catch (lookupError) {
+        // Fail-closed on DB lookup errors in this security-critical check.
+        // (Per security boundary discipline: a transient DB failure must not
+        // become an authentication bypass for stale tokens.)
+        logger.error(
+          `[auth:${requestId}] passwordChangedAt lookup failed for user ${user.id}: ${lookupError.message}`,
+        );
+        return respondUnauthorized('Authentication unavailable. Please retry.');
+      }
+    }
 
     req.user = user;
     logger.info(`[auth:${requestId}] Authenticated user ${user.id}`);

--- a/backend/modules/auth/controllers/authController.mjs
+++ b/backend/modules/auth/controllers/authController.mjs
@@ -660,14 +660,18 @@ export const changePassword = async (req, res, next) => {
     const saltRounds = parseInt(process.env.BCRYPT_SALT_ROUNDS || '12', 10);
     const hashedPassword = await bcrypt.hash(newPassword, saltRounds);
 
-    // Update password in database
+    // Update password in database. Stamp passwordChangedAt so the JWT-verify
+    // middleware (CWE-613) can reject any access tokens issued before now —
+    // closes the residual ≤access-token-TTL window where a stolen token would
+    // otherwise outlive the password rotation.
     await prisma.user.update({
       where: { id: req.user.id },
-      data: { password: hashedPassword },
+      data: { password: hashedPassword, passwordChangedAt: new Date() },
     });
 
-    // ✅ CWE-613 MITIGATION: Invalidate ALL sessions across all devices
-    // This forces the user to re-login everywhere after password change for security
+    // ✅ CWE-613 MITIGATION: Invalidate ALL refresh tokens across all devices
+    // (access tokens are invalidated separately via the passwordChangedAt
+    // check in authenticateToken). Forces re-login everywhere after rotation.
     await prisma.refreshToken.deleteMany({
       where: { userId: req.user.id },
     });
@@ -809,10 +813,12 @@ export const resetPassword = async (req, res, next) => {
     }
 
     // Apply writes atomically: update password, mark token used, invalidate sessions.
+    // passwordChangedAt is stamped so the JWT-verify middleware (CWE-613) rejects
+    // any access tokens issued before this reset — closes the residual window.
     await prisma.$transaction(async tx => {
       await tx.user.update({
         where: { id: resetToken.userId },
-        data: { password: hashedPassword },
+        data: { password: hashedPassword, passwordChangedAt: new Date() },
       });
       await tx.$executeRawUnsafe(
         'UPDATE password_reset_tokens SET "usedAt" = NOW() WHERE id = $1',

--- a/packages/database/prisma/migrations/20260501120000_add_user_password_changed_at/migration.sql
+++ b/packages/database/prisma/migrations/20260501120000_add_user_password_changed_at/migration.sql
@@ -1,0 +1,6 @@
+-- CWE-613 mitigation: track last password rotation time so the JWT-verify
+-- middleware can reject access tokens whose `iat` predates the rotation.
+-- Nullable: existing rows have no constraint (users who have never rotated
+-- their password retain valid pre-existing sessions until natural expiry).
+
+ALTER TABLE "User" ADD COLUMN "passwordChangedAt" TIMESTAMP(3);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -17,6 +17,10 @@ model User {
   email            String            @unique
   /// Hashed password
   password         String
+  /// Timestamp of last password change. CWE-613 mitigation: tokens with iat older than
+  /// this value are rejected by authenticateToken. Null = no constraint (existing users
+  /// who have never rotated their password — legacy sessions remain valid until natural expiry).
+  passwordChangedAt DateTime?
   /// First and last name for display purposes
   firstName        String
   lastName         String


### PR DESCRIPTION
## Summary

Closes CWE-613 (Insufficient Session Expiration). Stamps `User.passwordChangedAt` on `changePassword` and `resetPassword`, and rejects JWTs whose `iat` predates that timestamp in the `authenticateToken` middleware. Closes the residual ≤access-token-TTL window where a stolen access token outlived a password rotation.

- Tracking issue: Equoria-39r5 (supersedes Equoria-zgwl)
- Independent of PR #109; branched off master.

## Implementation

- `packages/database/prisma/schema.prisma` — `passwordChangedAt: DateTime?` on User. Null = no constraint (existing users who never rotated retain valid sessions until natural expiry).
- `packages/database/prisma/migrations/20260501120000_add_user_password_changed_at/migration.sql` — `ALTER TABLE \"User\" ADD COLUMN`. Applied to dev + test DBs.
- `backend/modules/auth/controllers/authController.mjs` — both `changePassword` and `resetPassword` now stamp `passwordChangedAt: new Date()` alongside the password update.
- `backend/middleware/auth.mjs` — `authenticateToken` is now async, looks up `passwordChangedAt`, rejects with 401 (`Session invalidated. Please login again.`) when `decoded.iat < Math.floor(passwordChangedAt.getTime() / 1000)`. Fail-closed on DB lookup errors. Type-guarded for non-string ids (mock/forged tokens).
- `backend/__tests__/integration/session-lifecycle.test.mjs` — strong sentinel-positive 401 assertion restored at the previously-weakened block (`session-lifecycle.test.mjs:766-789`); `beforeEach` resets `passwordChangedAt` for the shared fixture user; 1.1s sleep before change-password to deterministically cross the JWT iat second boundary.
- `backend/__tests__/unit/security/token-validation.test.mjs` — `it()` callbacks now async and `await authenticateToken(req, res, next)`, required by the now-async middleware.

## Design notes

- **Per-request DB lookup** chosen over caching for v1. Adds ~1-5ms latency per authenticated request. Caching follow-up filed as Equoria-2bbf.
- **JWT iat second-precision** means a 1-second window exists at password change time where a same-second-issued token still authenticates. Documented inline; deemed acceptable trade-off (real users take far longer than 1s to re-authenticate).
- **Adjacent locations** surveyed (OPTIMAL_FIX_DISCIPLINE §3): registration creates user with null `passwordChangedAt` (correct); `forgotPassword` doesn't touch the password (correct). No other production paths mutate the password.

## What was NOT done (filed as follow-ups)

- **Equoria-blku** — parallel sentinel test for `resetPassword` path (the middleware uniformly protects both, but the strong-assertion test only covers `changePassword`).
- **Equoria-ttbd** — apply the same check to `optionalAuth` middleware (currently skipped for perf reasons; needs audit of optional-auth endpoints).
- **Equoria-2bbf** — cache `passwordChangedAt` to remove the per-request DB hit.

## Test plan

- [x] `__tests__/integration/session-lifecycle.test.mjs` — 14/14 passing; strong CWE-613 assertion verified to fail without the middleware fix and pass with it (sentinel-positive per OPTIMAL_FIX_DISCIPLINE §2).
- [x] auth/session/security/middleware suites — 529/529 passing across 32 suites.
- [x] Full backend suite — 4832/4832 passing across 275 suites (424s).
- [ ] CI run on this branch (Dependabot/audit-level gates) — to be observed when CI fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Active sessions are now automatically invalidated when users change their password.
  * Users must re-authenticate after a password change to continue using the application.
  * Improved protection against unauthorized access by preventing the reuse of sessions after password rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->